### PR TITLE
Add Ion parsing diagnostics to LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,108 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "covalence-ion"
 version = "0.1.0"
+dependencies = [
+ "ion-rs",
+]
 
 [[package]]
 name = "covalence-lsp"
@@ -39,6 +133,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fluent-uri"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,10 +159,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ice_code"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6524844f553e8da5999f3000cf11d3f1ff926bb03fc087441c7b86dee4a7d48"
+
+[[package]]
+name = "ion-rs"
+version = "1.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1635de5984b66df8c9061125d02235c7e04c575d45cd93dbd85e14e307c06695"
+dependencies = [
+ "arrayvec",
+ "base64",
+ "bumpalo",
+ "chrono",
+ "compact_str",
+ "delegate",
+ "ice_code",
+ "num-integer",
+ "num-traits",
+ "phf",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "log"
@@ -92,6 +271,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +353,39 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
@@ -164,6 +442,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,10 +477,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/covalence-ion/Cargo.toml
+++ b/crates/covalence-ion/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+ion-rs = "1.0.0-rc.11"

--- a/crates/covalence-ion/src/lib.rs
+++ b/crates/covalence-ion/src/lib.rs
@@ -1,0 +1,1 @@
+pub use ion_rs;

--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -2,6 +2,7 @@ use lsp_server::{Request, Response};
 use lsp_types::{
     Diagnostic, DiagnosticSeverity, InitializeResult, Position, PublishDiagnosticsParams, Range,
     ServerCapabilities, ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind,
+    notification::Notification as _,
 };
 
 pub fn server_capabilities() -> ServerCapabilities {
@@ -53,45 +54,37 @@ pub fn diagnose(text: &str) -> Vec<Diagnostic> {
     }
 }
 
-fn publish_diagnostics(
-    uri: lsp_types::Uri,
-    text: &str,
-) -> lsp_server::Notification {
+fn publish_diagnostics(uri: lsp_types::Uri, text: &str) -> lsp_server::Notification {
     let diagnostics = diagnose(text);
     let params = PublishDiagnosticsParams {
         uri,
         diagnostics,
         version: None,
     };
-    lsp_server::Notification {
-        method: "textDocument/publishDiagnostics".to_owned(),
-        params: serde_json::to_value(params).unwrap(),
-    }
+    lsp_server::Notification::new(
+        lsp_types::notification::PublishDiagnostics::METHOD.to_owned(),
+        serde_json::to_value(params).unwrap(),
+    )
 }
 
-pub fn handle_notification(not: &lsp_server::Notification) -> Vec<lsp_server::Notification> {
-    match not.method.as_str() {
-        "textDocument/didOpen" => {
+pub fn handle_notification(not: lsp_server::Notification) -> Option<lsp_server::Notification> {
+    let lsp_server::Notification { method, params } = not;
+    match method.as_str() {
+        lsp_types::notification::DidOpenTextDocument::METHOD => {
             let params: lsp_types::DidOpenTextDocumentParams =
-                serde_json::from_value(not.params.clone()).unwrap();
-            vec![publish_diagnostics(
+                serde_json::from_value(params).ok()?;
+            Some(publish_diagnostics(
                 params.text_document.uri,
                 &params.text_document.text,
-            )]
+            ))
         }
-        "textDocument/didChange" => {
+        lsp_types::notification::DidChangeTextDocument::METHOD => {
             let params: lsp_types::DidChangeTextDocumentParams =
-                serde_json::from_value(not.params.clone()).unwrap();
-            if let Some(change) = params.content_changes.into_iter().last() {
-                vec![publish_diagnostics(
-                    params.text_document.uri,
-                    &change.text,
-                )]
-            } else {
-                vec![]
-            }
+                serde_json::from_value(params).ok()?;
+            let change = params.content_changes.into_iter().last()?;
+            Some(publish_diagnostics(params.text_document.uri, &change.text))
         }
-        _ => vec![],
+        _ => None,
     }
 }
 

--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -1,8 +1,14 @@
 use lsp_server::{Request, Response};
-use lsp_types::{InitializeResult, ServerCapabilities, ServerInfo};
+use lsp_types::{
+    Diagnostic, DiagnosticSeverity, InitializeResult, Position, PublishDiagnosticsParams, Range,
+    ServerCapabilities, ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind,
+};
 
 pub fn server_capabilities() -> ServerCapabilities {
-    ServerCapabilities::default()
+    ServerCapabilities {
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        ..Default::default()
+    }
 }
 
 pub fn initialize_result() -> InitializeResult {
@@ -33,4 +39,76 @@ pub fn handle_request(req: &Request) -> Option<Response> {
     }
 }
 
-pub fn handle_notification(_not: &lsp_server::Notification) {}
+pub fn diagnose(text: &str) -> Vec<Diagnostic> {
+    use covalence_ion::ion_rs::Element;
+
+    match Element::read_all(text.as_bytes()) {
+        Ok(_) => vec![],
+        Err(e) => vec![Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
+            severity: Some(DiagnosticSeverity::ERROR),
+            message: e.to_string(),
+            ..Default::default()
+        }],
+    }
+}
+
+fn publish_diagnostics(
+    uri: lsp_types::Uri,
+    text: &str,
+) -> lsp_server::Notification {
+    let diagnostics = diagnose(text);
+    let params = PublishDiagnosticsParams {
+        uri,
+        diagnostics,
+        version: None,
+    };
+    lsp_server::Notification {
+        method: "textDocument/publishDiagnostics".to_owned(),
+        params: serde_json::to_value(params).unwrap(),
+    }
+}
+
+pub fn handle_notification(not: &lsp_server::Notification) -> Vec<lsp_server::Notification> {
+    match not.method.as_str() {
+        "textDocument/didOpen" => {
+            let params: lsp_types::DidOpenTextDocumentParams =
+                serde_json::from_value(not.params.clone()).unwrap();
+            vec![publish_diagnostics(
+                params.text_document.uri,
+                &params.text_document.text,
+            )]
+        }
+        "textDocument/didChange" => {
+            let params: lsp_types::DidChangeTextDocumentParams =
+                serde_json::from_value(not.params.clone()).unwrap();
+            if let Some(change) = params.content_changes.into_iter().last() {
+                vec![publish_diagnostics(
+                    params.text_document.uri,
+                    &change.text,
+                )]
+            } else {
+                vec![]
+            }
+        }
+        _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn well_formed_ion_no_diagnostics() {
+        assert!(diagnose("{ name: \"hello\", value: 42 }").is_empty());
+        assert!(diagnose("null").is_empty());
+        assert!(diagnose("true false 1 2 3").is_empty());
+        assert!(diagnose("").is_empty());
+    }
+
+    #[test]
+    fn malformed_ion_has_errors() {
+        assert!(!diagnose("{ name: }").is_empty());
+    }
+}

--- a/crates/covalence-lsp/src/main.rs
+++ b/crates/covalence-lsp/src/main.rs
@@ -2,6 +2,23 @@ use lsp_server::{Connection, Message};
 use lsp_types::InitializeParams;
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.get(1).is_some_and(|a| a == "--diagnose") {
+        let path = args.get(2).expect("usage: covalence-lsp --diagnose <file>");
+        let text = std::fs::read_to_string(path).unwrap();
+        let diagnostics = covalence_lsp::diagnose(&text);
+        for d in &diagnostics {
+            let severity = match d.severity {
+                Some(lsp_types::DiagnosticSeverity::ERROR) => "error",
+                Some(lsp_types::DiagnosticSeverity::WARNING) => "warning",
+                _ => "info",
+            };
+            eprintln!("{}: {}", severity, d.message);
+        }
+        std::process::exit(if diagnostics.is_empty() { 0 } else { 1 });
+    }
+
     let (connection, io_threads) = Connection::stdio();
 
     let (init_id, _init_params) = connection.initialize_start().unwrap();
@@ -26,7 +43,9 @@ fn main() {
                 }
             }
             Message::Notification(not) => {
-                covalence_lsp::handle_notification(&not);
+                for n in covalence_lsp::handle_notification(&not) {
+                    connection.sender.send(Message::Notification(n)).unwrap();
+                }
             }
             Message::Response(_) => {}
         }

--- a/crates/covalence-lsp/src/main.rs
+++ b/crates/covalence-lsp/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
                 }
             }
             Message::Notification(not) => {
-                for n in covalence_lsp::handle_notification(&not) {
+                if let Some(n) = covalence_lsp::handle_notification(not) {
                     connection.sender.send(Message::Notification(n)).unwrap();
                 }
             }


### PR DESCRIPTION
## Summary

- **covalence-ion** re-exports `ion-rs` (1.0.0-rc.11)
- **covalence-lsp** parses Ion on `didOpen`/`didChange` and publishes diagnostics on parse failure (highlights the whole file for now)
- Adds `--diagnose <file>` CLI mode that prints diagnostics to stderr and exits with code 0 (clean) or 1 (errors)
- Adds tests: well-formed Ion produces no diagnostics, malformed Ion emits at least one error

## Test plan

- [ ] `cargo run -p covalence-lsp -- --diagnose <valid.ion>` exits 0
- [x] `cargo test --lib -p covalence-lsp` — 2 tests pass (well-formed and malformed Ion)
- [ ] `cargo run -p covalence-lsp -- --diagnose <invalid.ion>` exits 1 with error on stderr
- [ ] Open a `.ion` file in VSCode with the extension — malformed Ion shows a diagnostic

https://claude.ai/code/session_01Qp9UuURUZnY5RBWgFpni4g