### PR TITLE
Add Ion AST pretty-printer and document formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -104,6 +110,7 @@ name = "covalence-ion"
 version = "0.1.0"
 dependencies = [
  "ion-rs",
+ "pretty",
 ]
 
 [[package]]
@@ -194,7 +201,7 @@ version = "1.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1635de5984b66df8c9061125d02235c7e04c575d45cd93dbd85e14e307c06695"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "base64",
  "bumpalo",
  "chrono",
@@ -334,6 +341,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width",
 ]
 
 [[package]]
@@ -497,10 +515,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/covalence-ion/Cargo.toml
+++ b/crates/covalence-ion/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 ion-rs = "1.0.0-rc.11"
+pretty = "0.12"

--- a/crates/covalence-ion/src/lib.rs
+++ b/crates/covalence-ion/src/lib.rs
@@ -1,1 +1,4 @@
 pub use ion_rs;
+
+mod prettyprint;
+pub use prettyprint::prettyprint;

--- a/crates/covalence-ion/src/prettyprint.rs
+++ b/crates/covalence-ion/src/prettyprint.rs
@@ -1,0 +1,335 @@
+use std::io;
+
+use ion_rs::{Element, IonType, Sequence, Struct, Value};
+use pretty::{Arena, DocAllocator, DocBuilder};
+
+const DEFAULT_WIDTH: usize = 80;
+const INDENT: isize = 2;
+
+/// Pretty-print a sequence of Ion elements to the given writer.
+pub fn prettyprint(ast: &Sequence, writer: &mut dyn io::Write) -> io::Result<()> {
+    let arena = Arena::<()>::new();
+    let docs: Vec<_> = ast.iter().map(|elem| element_to_doc(&arena, elem)).collect();
+    if docs.is_empty() {
+        return Ok(());
+    }
+    let doc = arena.intersperse(docs, arena.hardline());
+    doc.1.render(DEFAULT_WIDTH, writer)
+}
+
+fn element_to_doc<'a>(arena: &'a Arena<'a>, elem: &Element) -> DocBuilder<'a, Arena<'a>> {
+    let value_doc = value_to_doc(arena, elem);
+    let mut doc = arena.nil();
+    for ann in elem.annotations() {
+        if let Some(text) = ann.text() {
+            doc = doc
+                .append(symbol_to_doc(arena, text))
+                .append(arena.text("::"));
+        }
+    }
+    doc.append(value_doc)
+}
+
+fn value_to_doc<'a>(arena: &'a Arena<'a>, elem: &Element) -> DocBuilder<'a, Arena<'a>> {
+    match elem.value() {
+        Value::Null(ion_type) => arena.text(null_text(*ion_type)),
+        Value::Bool(b) => arena.text(if *b { "true" } else { "false" }),
+        Value::Int(i) => arena.text(i.to_string()),
+        Value::Float(f) => float_to_doc(arena, *f),
+        Value::Decimal(d) => arena.text(d.to_string()),
+        Value::Timestamp(t) => arena.text(t.to_string()),
+        Value::Symbol(s) => match s.text() {
+            Some(text) => symbol_to_doc(arena, text),
+            None => arena.text("$0"),
+        },
+        Value::String(s) => arena.text(format!("\"{}\"", escape_string(s.text()))),
+        Value::Blob(b) => arena.text(format!("{{ {} }}", base64_encode(b.as_ref()))),
+        Value::Clob(c) => arena.text(format!("{{ \"{}\" }}", escape_clob(c.as_ref()))),
+        Value::List(seq) => list_to_doc(arena, seq),
+        Value::SExp(seq) => sexp_to_doc(arena, seq),
+        Value::Struct(s) => struct_to_doc(arena, s),
+    }
+}
+
+fn null_text(ion_type: IonType) -> &'static str {
+    match ion_type {
+        IonType::Null => "null",
+        IonType::Bool => "null.bool",
+        IonType::Int => "null.int",
+        IonType::Float => "null.float",
+        IonType::Decimal => "null.decimal",
+        IonType::Timestamp => "null.timestamp",
+        IonType::Symbol => "null.symbol",
+        IonType::String => "null.string",
+        IonType::Clob => "null.clob",
+        IonType::Blob => "null.blob",
+        IonType::List => "null.list",
+        IonType::SExp => "null.sexp",
+        IonType::Struct => "null.struct",
+    }
+}
+
+fn float_to_doc<'a>(arena: &'a Arena<'a>, f: f64) -> DocBuilder<'a, Arena<'a>> {
+    if f.is_nan() {
+        arena.text("nan")
+    } else if f == f64::INFINITY {
+        arena.text("+inf")
+    } else if f == f64::NEG_INFINITY {
+        arena.text("-inf")
+    } else {
+        arena.text(format!("{:e}", f))
+    }
+}
+
+fn needs_quoting(text: &str) -> bool {
+    if text.is_empty() {
+        return true;
+    }
+    match text {
+        "null" | "true" | "false" | "nan" => return true,
+        _ => {}
+    }
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
+        _ => return true,
+    }
+    for c in chars {
+        if !c.is_ascii_alphanumeric() && c != '_' && c != '$' {
+            return true;
+        }
+    }
+    false
+}
+
+fn symbol_to_doc<'a>(arena: &'a Arena<'a>, text: &str) -> DocBuilder<'a, Arena<'a>> {
+    if needs_quoting(text) {
+        arena.text(format!("'{}'", escape_symbol(text)))
+    } else {
+        arena.text(text.to_owned())
+    }
+}
+
+fn escape_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\0' => out.push_str("\\0"),
+            c if c.is_control() => {
+                for byte in c.to_string().bytes() {
+                    out.push_str(&format!("\\x{:02x}", byte));
+                }
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn escape_symbol(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\'' => out.push_str("\\'"),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\0' => out.push_str("\\0"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn escape_clob(data: &[u8]) -> String {
+    let mut out = String::new();
+    for &b in data {
+        match b {
+            b'"' => out.push_str("\\\""),
+            b'\\' => out.push_str("\\\\"),
+            b'\n' => out.push_str("\\n"),
+            b'\r' => out.push_str("\\r"),
+            b'\t' => out.push_str("\\t"),
+            0 => out.push_str("\\0"),
+            b if b.is_ascii_graphic() || b == b' ' => out.push(b as char),
+            b => out.push_str(&format!("\\x{:02x}", b)),
+        }
+    }
+    out
+}
+
+fn base64_encode(data: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::with_capacity((data.len() + 2) / 3 * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        result.push(CHARS[((n >> 18) & 63) as usize] as char);
+        result.push(CHARS[((n >> 12) & 63) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(CHARS[((n >> 6) & 63) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(CHARS[(n & 63) as usize] as char);
+        } else {
+            result.push('=');
+        }
+    }
+    result
+}
+
+fn list_to_doc<'a>(arena: &'a Arena<'a>, seq: &Sequence) -> DocBuilder<'a, Arena<'a>> {
+    if seq.is_empty() {
+        return arena.text("[]");
+    }
+    let elems: Vec<_> = seq.iter().map(|e| element_to_doc(arena, e)).collect();
+    let sep = arena.text(",").append(arena.line());
+    arena
+        .text("[")
+        .append(
+            arena
+                .line_()
+                .append(arena.intersperse(elems, sep))
+                .nest(INDENT),
+        )
+        .append(arena.line_())
+        .append(arena.text("]"))
+        .group()
+}
+
+fn sexp_to_doc<'a>(arena: &'a Arena<'a>, seq: &Sequence) -> DocBuilder<'a, Arena<'a>> {
+    if seq.is_empty() {
+        return arena.text("()");
+    }
+    let elems: Vec<_> = seq.iter().map(|e| element_to_doc(arena, e)).collect();
+    let sep = arena.line();
+    arena
+        .text("(")
+        .append(
+            arena
+                .line_()
+                .append(arena.intersperse(elems, sep))
+                .nest(INDENT),
+        )
+        .append(arena.line_())
+        .append(arena.text(")"))
+        .group()
+}
+
+fn struct_to_doc<'a>(arena: &'a Arena<'a>, s: &Struct) -> DocBuilder<'a, Arena<'a>> {
+    if s.is_empty() {
+        return arena.text("{}");
+    }
+    let fields: Vec<_> = s
+        .fields()
+        .map(|(name, value)| {
+            let name_doc = match name.text() {
+                Some(text) => symbol_to_doc(arena, text),
+                None => arena.text("$0"),
+            };
+            name_doc
+                .append(arena.text(":"))
+                .append(arena.text(" "))
+                .append(element_to_doc(arena, value))
+        })
+        .collect();
+    let sep = arena.text(",").append(arena.line());
+    arena
+        .text("{")
+        .append(
+            arena
+                .line()
+                .append(arena.intersperse(fields, sep))
+                .nest(INDENT),
+        )
+        .append(arena.line())
+        .append(arena.text("}"))
+        .group()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ion_rs::Element;
+
+    fn format(input: &str) -> String {
+        let seq = Element::read_all(input.as_bytes()).unwrap();
+        let mut buf = Vec::new();
+        prettyprint(&seq, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn scalars() {
+        assert_eq!(format("null"), "null");
+        assert_eq!(format("null.int"), "null.int");
+        assert_eq!(format("true"), "true");
+        assert_eq!(format("false"), "false");
+        assert_eq!(format("42"), "42");
+        assert_eq!(format("\"hello\""), "\"hello\"");
+    }
+
+    #[test]
+    fn symbols() {
+        assert_eq!(format("foo"), "foo");
+        assert_eq!(format("'hello world'"), "'hello world'");
+        assert_eq!(format("'null'"), "'null'");
+        assert_eq!(format("'true'"), "'true'");
+    }
+
+    #[test]
+    fn simple_struct() {
+        assert_eq!(format("{ a: 1, b: 2 }"), "{ a: 1, b: 2 }");
+    }
+
+    #[test]
+    fn simple_list() {
+        assert_eq!(format("[1, 2, 3]"), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn simple_sexp() {
+        assert_eq!(format("(+ 1 2)"), "('+' 1 2)");
+        assert_eq!(format("(foo 1 2)"), "(foo 1 2)");
+    }
+
+    #[test]
+    fn empty_containers() {
+        assert_eq!(format("[]"), "[]");
+        assert_eq!(format("()"), "()");
+        assert_eq!(format("{}"), "{}");
+    }
+
+    #[test]
+    fn annotations() {
+        assert_eq!(format("foo::42"), "foo::42");
+        assert_eq!(format("foo::bar::42"), "foo::bar::42");
+    }
+
+    #[test]
+    fn nested_struct_breaks() {
+        let input = "{ alpha: 1, bravo: 2, charlie: 3, delta: 4, echo: 5, foxtrot: 6, golf: 7, hotel: 8 }";
+        let output = format(input);
+        assert!(output.contains('\n'), "long struct should break across lines: {output}");
+    }
+
+    #[test]
+    fn multiple_top_level() {
+        assert_eq!(format("1 2 3"), "1\n2\n3");
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(format(""), "");
+    }
+}

--- a/crates/covalence-ion/src/prettyprint.rs
+++ b/crates/covalence-ion/src/prettyprint.rs
@@ -378,6 +378,35 @@ mod tests {
     }
 
     #[test]
+    fn string_escapes() {
+        // Named control character escapes
+        assert_eq!(format("\"\\0\""), "\"\\0\"");
+        assert_eq!(format("\"\\a\""), "\"\\a\"");
+        assert_eq!(format("\"\\b\""), "\"\\b\"");
+        assert_eq!(format("\"\\t\""), "\"\\t\"");
+        assert_eq!(format("\"\\n\""), "\"\\n\"");
+        assert_eq!(format("\"\\v\""), "\"\\v\"");
+        assert_eq!(format("\"\\f\""), "\"\\f\"");
+        assert_eq!(format("\"\\r\""), "\"\\r\"");
+        // Quote and backslash escaping
+        assert_eq!(format("\"hello\\\"world\""), "\"hello\\\"world\"");
+        assert_eq!(format("\"back\\\\slash\""), "\"back\\\\slash\"");
+        // Unicode escape for other control chars (e.g. U+001B ESC)
+        assert_eq!(format("\"\\x1b\""), "\"\\u001b\"");
+    }
+
+    #[test]
+    fn symbol_escapes() {
+        // Symbols with characters requiring quoting and escaping
+        assert_eq!(format("'has\\'quote'"), "'has\\'quote'");
+        assert_eq!(format("'has\\\\backslash'"), "'has\\\\backslash'");
+        assert_eq!(format("'has\\nnewline'"), "'has\\nnewline'");
+        assert_eq!(format("'has\\ttab'"), "'has\\ttab'");
+        // Unicode escape for control chars in symbols
+        assert_eq!(format("'esc\\x1b'"), "'esc\\u001b'");
+    }
+
+    #[test]
     fn floats() {
         assert_eq!(format("0e0"), "0e0");
         assert_eq!(format("nan"), "nan");

--- a/crates/covalence-ion/src/prettyprint.rs
+++ b/crates/covalence-ion/src/prettyprint.rs
@@ -116,13 +116,20 @@ fn escape_string(s: &str) -> String {
         match c {
             '"' => out.push_str("\\\""),
             '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
             '\0' => out.push_str("\\0"),
+            '\x07' => out.push_str("\\a"),
+            '\x08' => out.push_str("\\b"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\x0b' => out.push_str("\\v"),
+            '\x0c' => out.push_str("\\f"),
+            '\r' => out.push_str("\\r"),
             c if c.is_control() => {
-                for byte in c.to_string().bytes() {
-                    out.push_str(&format!("\\x{:02x}", byte));
+                let cp = c as u32;
+                if cp <= 0xFFFF {
+                    out.push_str(&format!("\\u{:04x}", cp));
+                } else {
+                    out.push_str(&format!("\\U{:08x}", cp));
                 }
             }
             c => out.push(c),
@@ -137,10 +144,18 @@ fn escape_symbol(s: &str) -> String {
         match c {
             '\'' => out.push_str("\\'"),
             '\\' => out.push_str("\\\\"),
+            '\0' => out.push_str("\\0"),
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
-            '\0' => out.push_str("\\0"),
+            c if c.is_control() => {
+                let cp = c as u32;
+                if cp <= 0xFFFF {
+                    out.push_str(&format!("\\u{:04x}", cp));
+                } else {
+                    out.push_str(&format!("\\U{:08x}", cp));
+                }
+            }
             c => out.push(c),
         }
     }
@@ -331,5 +346,42 @@ mod tests {
     #[test]
     fn empty_input() {
         assert_eq!(format(""), "");
+    }
+
+    #[test]
+    fn roundtrip_preserves_semantics() {
+        let inputs = [
+            "null",
+            "null.struct",
+            "true",
+            "42",
+            "\"hello\\nworld\"",
+            "foo",
+            "'quoted symbol'",
+            "[1, 2, 3]",
+            "(a b c)",
+            "{ x: 1, y: \"two\" }",
+            "ann::42",
+            "a::b::[1, 2]",
+            "{ nested: { inner: [true, false] } }",
+        ];
+        for input in inputs {
+            let original = Element::read_all(input.as_bytes()).unwrap();
+            let formatted = format(input);
+            let reparsed = Element::read_all(formatted.as_bytes())
+                .unwrap_or_else(|e| panic!("failed to reparse formatted output for {input:?}: {e}\nformatted: {formatted:?}"));
+            assert_eq!(
+                original, reparsed,
+                "roundtrip mismatch for {input:?}\nformatted: {formatted:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn floats() {
+        assert_eq!(format("0e0"), "0e0");
+        assert_eq!(format("nan"), "nan");
+        assert_eq!(format("+inf"), "+inf");
+        assert_eq!(format("-inf"), "-inf");
     }
 }

--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -1,13 +1,18 @@
+use std::collections::HashMap;
+
 use lsp_server::{Request, Response};
 use lsp_types::{
-    Diagnostic, DiagnosticSeverity, InitializeResult, Position, PublishDiagnosticsParams, Range,
-    ServerCapabilities, ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind,
+    Diagnostic, DiagnosticSeverity, DocumentFormattingParams, InitializeResult, OneOf, Position,
+    PublishDiagnosticsParams, Range, ServerCapabilities, ServerInfo, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextEdit, Uri,
     notification::Notification as _,
+    request::Request as _,
 };
 
 pub fn server_capabilities() -> ServerCapabilities {
     ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        document_formatting_provider: Some(OneOf::Left(true)),
         ..Default::default()
     }
 }
@@ -24,19 +29,96 @@ pub fn initialize_result() -> InitializeResult {
 
 const MESSAGE: &str = "Hello from Covalence LSP!";
 
-pub fn handle_request(req: &Request) -> Option<Response> {
-    match req.method.as_str() {
-        "covalence/helloWorld" => {
-            let result = serde_json::json!({
-                "message": MESSAGE
-            });
-            Some(Response::new_ok(req.id.clone(), result))
+pub struct Server {
+    documents: HashMap<Uri, String>,
+}
+
+impl Server {
+    pub fn new() -> Self {
+        Server {
+            documents: HashMap::new(),
         }
-        _ => Some(Response::new_err(
-            req.id.clone(),
-            lsp_server::ErrorCode::MethodNotFound as i32,
-            format!("unknown method: {}", req.method),
-        )),
+    }
+
+    pub fn handle_request(&self, req: &Request) -> Option<Response> {
+        match req.method.as_str() {
+            "covalence/helloWorld" => {
+                let result = serde_json::json!({
+                    "message": MESSAGE
+                });
+                Some(Response::new_ok(req.id.clone(), result))
+            }
+            lsp_types::request::Formatting::METHOD => {
+                let params: DocumentFormattingParams =
+                    serde_json::from_value(req.params.clone()).ok()?;
+                let result = self.handle_formatting(&params);
+                Some(Response::new_ok(
+                    req.id.clone(),
+                    serde_json::to_value(result).unwrap(),
+                ))
+            }
+            _ => Some(Response::new_err(
+                req.id.clone(),
+                lsp_server::ErrorCode::MethodNotFound as i32,
+                format!("unknown method: {}", req.method),
+            )),
+        }
+    }
+
+    fn handle_formatting(&self, params: &DocumentFormattingParams) -> Option<Vec<TextEdit>> {
+        let uri = &params.text_document.uri;
+        let text = self.documents.get(uri)?;
+
+        use covalence_ion::ion_rs::Element;
+        let ast = Element::read_all(text.as_bytes()).ok()?;
+
+        let mut buf = Vec::new();
+        covalence_ion::prettyprint(&ast, &mut buf).ok()?;
+        let formatted = String::from_utf8(buf).ok()?;
+
+        // Add trailing newline
+        let formatted = if formatted.is_empty() {
+            formatted
+        } else {
+            formatted + "\n"
+        };
+
+        Some(vec![TextEdit {
+            range: Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
+            new_text: formatted,
+        }])
+    }
+
+    pub fn handle_notification(
+        &mut self,
+        not: lsp_server::Notification,
+    ) -> Option<lsp_server::Notification> {
+        let lsp_server::Notification { method, params } = not;
+        match method.as_str() {
+            lsp_types::notification::DidOpenTextDocument::METHOD => {
+                let params: lsp_types::DidOpenTextDocumentParams =
+                    serde_json::from_value(params).ok()?;
+                let uri = params.text_document.uri.clone();
+                let text = params.text_document.text.clone();
+                self.documents.insert(uri, text.clone());
+                Some(publish_diagnostics(params.text_document.uri, &text))
+            }
+            lsp_types::notification::DidChangeTextDocument::METHOD => {
+                let params: lsp_types::DidChangeTextDocumentParams =
+                    serde_json::from_value(params).ok()?;
+                let change = params.content_changes.into_iter().last()?;
+                let uri = params.text_document.uri.clone();
+                self.documents.insert(uri, change.text.clone());
+                Some(publish_diagnostics(params.text_document.uri, &change.text))
+            }
+            lsp_types::notification::DidCloseTextDocument::METHOD => {
+                let params: lsp_types::DidCloseTextDocumentParams =
+                    serde_json::from_value(params).ok()?;
+                self.documents.remove(&params.text_document.uri);
+                None
+            }
+            _ => None,
+        }
     }
 }
 
@@ -54,7 +136,7 @@ pub fn diagnose(text: &str) -> Vec<Diagnostic> {
     }
 }
 
-fn publish_diagnostics(uri: lsp_types::Uri, text: &str) -> lsp_server::Notification {
+fn publish_diagnostics(uri: Uri, text: &str) -> lsp_server::Notification {
     let diagnostics = diagnose(text);
     let params = PublishDiagnosticsParams {
         uri,
@@ -65,27 +147,6 @@ fn publish_diagnostics(uri: lsp_types::Uri, text: &str) -> lsp_server::Notificat
         lsp_types::notification::PublishDiagnostics::METHOD.to_owned(),
         serde_json::to_value(params).unwrap(),
     )
-}
-
-pub fn handle_notification(not: lsp_server::Notification) -> Option<lsp_server::Notification> {
-    let lsp_server::Notification { method, params } = not;
-    match method.as_str() {
-        lsp_types::notification::DidOpenTextDocument::METHOD => {
-            let params: lsp_types::DidOpenTextDocumentParams =
-                serde_json::from_value(params).ok()?;
-            Some(publish_diagnostics(
-                params.text_document.uri,
-                &params.text_document.text,
-            ))
-        }
-        lsp_types::notification::DidChangeTextDocument::METHOD => {
-            let params: lsp_types::DidChangeTextDocumentParams =
-                serde_json::from_value(params).ok()?;
-            let change = params.content_changes.into_iter().last()?;
-            Some(publish_diagnostics(params.text_document.uri, &change.text))
-        }
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -49,8 +49,16 @@ impl Server {
                 Some(Response::new_ok(req.id.clone(), result))
             }
             lsp_types::request::Formatting::METHOD => {
-                let params: DocumentFormattingParams =
-                    serde_json::from_value(req.params.clone()).ok()?;
+                let params: DocumentFormattingParams = match serde_json::from_value(req.params.clone()) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return Some(Response::new_err(
+                            req.id.clone(),
+                            lsp_server::ErrorCode::InvalidParams as i32,
+                            e.to_string(),
+                        ));
+                    }
+                };
                 let result = self.handle_formatting(&params);
                 Some(Response::new_ok(
                     req.id.clone(),
@@ -98,18 +106,20 @@ impl Server {
             lsp_types::notification::DidOpenTextDocument::METHOD => {
                 let params: lsp_types::DidOpenTextDocumentParams =
                     serde_json::from_value(params).ok()?;
-                let uri = params.text_document.uri.clone();
-                let text = params.text_document.text.clone();
-                self.documents.insert(uri, text.clone());
-                Some(publish_diagnostics(params.text_document.uri, &text))
+                let uri = params.text_document.uri;
+                let text = params.text_document.text;
+                let diagnostics = publish_diagnostics(uri.clone(), &text);
+                self.documents.insert(uri, text);
+                Some(diagnostics)
             }
             lsp_types::notification::DidChangeTextDocument::METHOD => {
                 let params: lsp_types::DidChangeTextDocumentParams =
                     serde_json::from_value(params).ok()?;
                 let change = params.content_changes.into_iter().last()?;
-                let uri = params.text_document.uri.clone();
-                self.documents.insert(uri, change.text.clone());
-                Some(publish_diagnostics(params.text_document.uri, &change.text))
+                let uri = params.text_document.uri;
+                let diagnostics = publish_diagnostics(uri.clone(), &change.text);
+                self.documents.insert(uri, change.text);
+                Some(diagnostics)
             }
             lsp_types::notification::DidCloseTextDocument::METHOD => {
                 let params: lsp_types::DidCloseTextDocumentParams =

--- a/crates/covalence-lsp/src/main.rs
+++ b/crates/covalence-lsp/src/main.rs
@@ -32,18 +32,20 @@ fn main() {
 
     eprintln!("Covalence LSP initialized");
 
+    let mut server = covalence_lsp::Server::new();
+
     for msg in &connection.receiver {
         match msg {
             Message::Request(req) => {
                 if connection.handle_shutdown(&req).unwrap_or(false) {
                     break;
                 }
-                if let Some(resp) = covalence_lsp::handle_request(&req) {
+                if let Some(resp) = server.handle_request(&req) {
                     connection.sender.send(Message::Response(resp)).unwrap();
                 }
             }
             Message::Notification(not) => {
-                if let Some(n) = covalence_lsp::handle_notification(not) {
+                if let Some(n) = server.handle_notification(not) {
                     connection.sender.send(Message::Notification(n)).unwrap();
                 }
             }


### PR DESCRIPTION
## Summary

- Add a pretty-printer for Ion ASTs in `covalence-ion` using the `pretty` crate's `Arena` allocator, exposed as a single `prettyprint(ast, writer)` function without leaking `pretty` as a public dependency
- Wire it into the LSP server as a `textDocument/formatting` handler, backed by a document store that tracks open file contents via `didOpen`/`didChange`/`didClose`
- Supports all Ion types: structs, lists, s-expressions, annotations, typed nulls, strings, symbols (with quoting), floats (nan/inf), blobs (base64), clobs, decimals, timestamps
- Containers use the `pretty` crate's group/nest/intersperse for smart line-breaking at 80 columns

## Test plan

- [x] Scalar rendering (null, typed null, bool, int, string)
- [x] Symbol quoting (bare identifiers vs quoted symbols, keywords)
- [x] Float special values (nan, +inf, -inf)
- [x] Container formatting (list, sexp, struct, empty containers)
- [x] Annotations (single and chained)
- [x] Line breaking for long structs
- [x] Multiple top-level values separated by newlines
- [x] Roundtrip test: format then reparse preserves Ion semantics
- [x] All 14 tests passing

https://claude.ai/code/session_01EMCbQKLkNdp6E3MVDxHZ12