### PR TITLE
Replace Hello World with binary Ion serialization byte counter

### DIFF
--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -25,10 +25,9 @@ pub fn initialize_result() -> InitializeResult {
 pub fn handle_request(req: &Request) -> Option<Response> {
     match req.method.as_str() {
         "covalence/serializeBinaryIon" => {
-            let params: serde_json::Value = serde_json::from_value(req.params.clone()).ok()?;
-            let text = params.get("text")?.as_str()?;
+            let text = req.params.get("text")?.as_str()?;
             let result = serialize_binary_ion(text);
-            Some(Response::new_ok(req.id.clone(), serde_json::to_value(result).unwrap()))
+            Some(Response::new_ok(req.id.clone(), result))
         }
         _ => Some(Response::new_err(
             req.id.clone(),

--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -22,21 +22,31 @@ pub fn initialize_result() -> InitializeResult {
     }
 }
 
-const MESSAGE: &str = "Hello from Covalence LSP!";
-
 pub fn handle_request(req: &Request) -> Option<Response> {
     match req.method.as_str() {
-        "covalence/helloWorld" => {
-            let result = serde_json::json!({
-                "message": MESSAGE
-            });
-            Some(Response::new_ok(req.id.clone(), result))
+        "covalence/serializeBinaryIon" => {
+            let params: serde_json::Value = serde_json::from_value(req.params.clone()).ok()?;
+            let text = params.get("text")?.as_str()?;
+            let result = serialize_binary_ion(text);
+            Some(Response::new_ok(req.id.clone(), serde_json::to_value(result).unwrap()))
         }
         _ => Some(Response::new_err(
             req.id.clone(),
             lsp_server::ErrorCode::MethodNotFound as i32,
             format!("unknown method: {}", req.method),
         )),
+    }
+}
+
+fn serialize_binary_ion(text: &str) -> serde_json::Value {
+    use covalence_ion::ion_rs::{Element, v1_0::Binary};
+
+    match Element::read_all(text.as_bytes()) {
+        Ok(sequence) => match sequence.encode_as(Binary) {
+            Ok(bytes) => serde_json::json!({ "byteCount": bytes.len() }),
+            Err(e) => serde_json::json!({ "error": e.to_string() }),
+        },
+        Err(e) => serde_json::json!({ "error": e.to_string() }),
     }
 }
 

--- a/extensions/covalence-vscode/package.json
+++ b/extensions/covalence-vscode/package.json
@@ -25,8 +25,8 @@
     ],
     "commands": [
       {
-        "command": "covalence.helloWorld",
-        "title": "Covalence: Hello World"
+        "command": "covalence.serializeBinaryIon",
+        "title": "Covalence: Serialize to Binary Ion (Count Bytes)"
       }
     ]
   },

--- a/extensions/covalence-vscode/src/extension.ts
+++ b/extensions/covalence-vscode/src/extension.ts
@@ -59,15 +59,34 @@ export async function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
-    commands.registerCommand("covalence.helloWorld", async () => {
+    commands.registerCommand("covalence.serializeBinaryIon", async () => {
       if (!client) {
         window.showErrorMessage("Covalence LSP is not running.");
         return;
       }
-      const result: { message: string } = await client.sendRequest(
-        "covalence/helloWorld",
-      );
-      window.showInformationMessage(result.message);
+      const editor = window.activeTextEditor;
+      if (!editor) {
+        window.showErrorMessage("No active editor.");
+        return;
+      }
+      const langId = editor.document.languageId;
+      const allowed = ["ion", "json", "jsonc", "json5", "jsonl"];
+      if (!allowed.includes(langId)) {
+        window.showErrorMessage(
+          `Unsupported language: ${langId}. Supported: ${allowed.join(", ")}`,
+        );
+        return;
+      }
+      const text = editor.document.getText();
+      const result: { byteCount?: number; error?: string } =
+        await client.sendRequest("covalence/serializeBinaryIon", { text });
+      if (result.error) {
+        window.showErrorMessage(`Ion serialization failed: ${result.error}`);
+      } else {
+        window.showInformationMessage(
+          `Binary Ion: ${result.byteCount} bytes`,
+        );
+      }
     }),
   );
 


### PR DESCRIPTION
## Summary

- Remove the placeholder `covalence.helloWorld` command and its LSP handler
- Add `covalence.serializeBinaryIon` command that parses active editor content as Ion text, serializes to binary Ion via `ion_rs`, and displays the byte count
- Works on Ion, JSON, JSONC, JSON5, and JSONL files (all parsed as Ion)

## Test plan

- [ ] Open an `.ion` file, run "Covalence: Serialize to Binary Ion (Count Bytes)" from the command palette — should show byte count
- [ ] Open a `.json` file, run the command — should parse as Ion and show byte count
- [ ] Open an unsupported file type (e.g. `.py`) — should show an error message
- [ ] Open a file with malformed Ion/JSON — should show a serialization error
- [ ] `cargo test -p covalence-lsp` passes

https://claude.ai/code/session_011FmBNJYqa8FKXLb4nmHaV1