### PR TITLE
Add binary Ion file support with prettyprinted text editing

### DIFF
--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -51,6 +51,34 @@ impl Server {
                 };
                 Some(Response::new_ok(req.id.clone(), result))
             }
+            "covalence/decodeBinaryIon" => {
+                let result = match req.params.get("path").and_then(|v| v.as_str()) {
+                    Some(path) => decode_binary_ion_file(path),
+                    None => {
+                        return Some(Response::new_err(
+                            req.id.clone(),
+                            lsp_server::ErrorCode::InvalidParams as i32,
+                            "missing or invalid \"path\" parameter".to_owned(),
+                        ));
+                    }
+                };
+                Some(Response::new_ok(req.id.clone(), result))
+            }
+            "covalence/encodeBinaryIon" => {
+                let path = req.params.get("path").and_then(|v| v.as_str());
+                let text = req.params.get("text").and_then(|v| v.as_str());
+                let result = match (path, text) {
+                    (Some(path), Some(text)) => encode_binary_ion_file(path, text),
+                    _ => {
+                        return Some(Response::new_err(
+                            req.id.clone(),
+                            lsp_server::ErrorCode::InvalidParams as i32,
+                            "missing or invalid \"path\" and/or \"text\" parameter".to_owned(),
+                        ));
+                    }
+                };
+                Some(Response::new_ok(req.id.clone(), result))
+            }
             lsp_types::request::Formatting::METHOD => {
                 let params: DocumentFormattingParams =
                     match serde_json::from_value(req.params.clone()) {
@@ -133,6 +161,45 @@ impl Server {
             }
             _ => None,
         }
+    }
+}
+
+fn decode_binary_ion_file(path: &str) -> serde_json::Value {
+    use covalence_ion::ion_rs::Element;
+
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => return serde_json::json!({ "error": format!("file read error: {e}") }),
+    };
+
+    match Element::read_all(&bytes) {
+        Ok(sequence) => {
+            let mut buf = Vec::new();
+            match covalence_ion::prettyprint(&sequence, &mut buf) {
+                Ok(()) => {
+                    let text = String::from_utf8(buf).unwrap_or_default();
+                    let text = if text.is_empty() { text } else { text + "\n" };
+                    serde_json::json!({ "text": text })
+                }
+                Err(e) => serde_json::json!({ "error": format!("prettyprint error: {e}") }),
+            }
+        }
+        Err(e) => serde_json::json!({ "error": format!("Ion parse error: {e}") }),
+    }
+}
+
+fn encode_binary_ion_file(path: &str, text: &str) -> serde_json::Value {
+    use covalence_ion::ion_rs::{Element, v1_0::Binary};
+
+    match Element::read_all(text.as_bytes()) {
+        Ok(sequence) => match sequence.encode_as(Binary) {
+            Ok(bytes) => match std::fs::write(path, &bytes) {
+                Ok(()) => serde_json::json!({}),
+                Err(e) => serde_json::json!({ "error": format!("file write error: {e}") }),
+            },
+            Err(e) => serde_json::json!({ "error": format!("binary encode error: {e}") }),
+        },
+        Err(e) => serde_json::json!({ "error": format!("Ion parse error: {e}") }),
     }
 }
 

--- a/extensions/covalence-vscode/package.json
+++ b/extensions/covalence-vscode/package.json
@@ -34,6 +34,14 @@
       {
         "command": "covalence.serializeBinaryIon",
         "title": "Covalence: Serialize to Binary Ion (Count Bytes)"
+      },
+      {
+        "command": "covalence.convertToIonBinary",
+        "title": "Covalence: Convert to Ion 1.0 Binary"
+      },
+      {
+        "command": "covalence.convertToIonText",
+        "title": "Covalence: Convert to Ion 1.0 Text"
       }
     ]
   },

--- a/extensions/covalence-vscode/src/extension.ts
+++ b/extensions/covalence-vscode/src/extension.ts
@@ -39,7 +39,7 @@ function isBinaryIon(bytes: Uint8Array): boolean {
 
 /** Extract a filesystem path from a file: URI string (e.g. "file:///foo" → "/foo"). */
 function fileUriToPath(uri: string): string {
-  return uri.replace(/^file:\/\//, "");
+  return decodeURIComponent(uri.replace(/^file:\/\//, ""));
 }
 
 let client: LanguageClient | undefined;
@@ -243,8 +243,11 @@ export async function activate(context: ExtensionContext) {
         return;
       }
 
-      // Close text editor and reopen as binary Ion view
-      await commands.executeCommand("workbench.action.closeActiveEditor");
+      // Close without saving — we already wrote binary via the LSP, so a
+      // normal save would overwrite it with the stale text content.
+      await commands.executeCommand(
+        "workbench.action.revertAndCloseActiveEditor",
+      );
       await openAsBinaryIon(editor.document.uri);
 
       window.showInformationMessage("Converted to Ion 1.0 Binary.");
@@ -286,12 +289,17 @@ export async function activate(context: ExtensionContext) {
         return;
       }
 
-      // The editor shows decoded text Ion — write it directly to the file
+      // Capture the decoded text before closing — getText() includes unsaved edits.
       const text = editor.document.getText();
-      await workspace.fs.writeFile(fileUri, new TextEncoder().encode(text));
 
-      // Close binary editor and reopen as text
-      await commands.executeCommand("workbench.action.closeActiveEditor");
+      // Close without saving first to prevent the FSP from re-encoding to
+      // binary (which would overwrite the text we're about to write).
+      await commands.executeCommand(
+        "workbench.action.revertAndCloseActiveEditor",
+      );
+
+      // Now write text Ion to the real file
+      await workspace.fs.writeFile(fileUri, new TextEncoder().encode(text));
       const doc = await workspace.openTextDocument(fileUri);
       await window.showTextDocument(doc);
 

--- a/extensions/covalence-vscode/src/extension.ts
+++ b/extensions/covalence-vscode/src/extension.ts
@@ -1,4 +1,17 @@
-import { ExtensionContext, Uri, commands, window, workspace } from "vscode";
+import {
+  Disposable,
+  EventEmitter,
+  ExtensionContext,
+  FileChangeEvent,
+  FileStat,
+  FileSystemProvider,
+  FileType,
+  Uri,
+  commands,
+  languages,
+  window,
+  workspace,
+} from "vscode";
 import {
   LanguageClient,
   type LanguageClientOptions,
@@ -11,11 +24,110 @@ import {
   startServer,
 } from "@vscode/wasm-wasi-lsp";
 
+const ION_BINARY_SCHEME = "ion-binary";
+
+// Ion Version Marker for Ion 1.0: 0xE0 0x01 0x00 0xEA
+function isBinaryIon(bytes: Uint8Array): boolean {
+  return (
+    bytes.length >= 4 &&
+    bytes[0] === 0xe0 &&
+    bytes[1] === 0x01 &&
+    bytes[2] === 0x00 &&
+    bytes[3] === 0xea
+  );
+}
+
+/** Extract a filesystem path from a file: URI string (e.g. "file:///foo" → "/foo"). */
+function fileUriToPath(uri: string): string {
+  return uri.replace(/^file:\/\//, "");
+}
+
 let client: LanguageClient | undefined;
+let clientReadyResolve: () => void;
+const clientReady = new Promise<void>((resolve) => {
+  clientReadyResolve = resolve;
+});
+
+/** Convert a VSCode URI to the server-side filesystem path the WASI process sees. */
+let toServerPath: (uri: Uri) => string;
+
+class IonBinaryFSProvider implements FileSystemProvider {
+  private _emitter = new EventEmitter<FileChangeEvent[]>();
+  readonly onDidChangeFile = this._emitter.event;
+
+  watch(): Disposable {
+    return new Disposable(() => {});
+  }
+
+  async stat(uri: Uri): Promise<FileStat> {
+    const realUri = uri.with({ scheme: "file" });
+    return workspace.fs.stat(realUri);
+  }
+
+  readDirectory(): Thenable<[string, FileType][]> {
+    throw new Error("Not supported");
+  }
+
+  createDirectory(): void {
+    throw new Error("Not supported");
+  }
+
+  async readFile(uri: Uri): Promise<Uint8Array> {
+    await clientReady;
+    const path = toServerPath(uri.with({ scheme: "file" }));
+
+    const result: { text?: string; error?: string } =
+      await client!.sendRequest("covalence/decodeBinaryIon", { path });
+
+    if (result.error) {
+      throw new Error(`Failed to decode binary Ion: ${result.error}`);
+    }
+
+    return new TextEncoder().encode(result.text || "");
+  }
+
+  async writeFile(uri: Uri, content: Uint8Array): Promise<void> {
+    await clientReady;
+    const path = toServerPath(uri.with({ scheme: "file" }));
+    const text = new TextDecoder().decode(content);
+
+    const result: { error?: string } = await client!.sendRequest(
+      "covalence/encodeBinaryIon",
+      { path, text },
+    );
+
+    if (result.error) {
+      throw new Error(`Failed to encode binary Ion: ${result.error}`);
+    }
+  }
+
+  delete(): void {
+    throw new Error("Not supported");
+  }
+
+  rename(): void {
+    throw new Error("Not supported");
+  }
+}
+
+async function openAsBinaryIon(fileUri: Uri): Promise<void> {
+  const ionUri = fileUri.with({ scheme: ION_BINARY_SCHEME });
+  const doc = await workspace.openTextDocument(ionUri);
+  await languages.setTextDocumentLanguage(doc, "ion");
+  await window.showTextDocument(doc);
+}
 
 export async function activate(context: ExtensionContext) {
   const channel = window.createOutputChannel("Covalence LSP");
   const wasm: Wasm = await Wasm.load();
+
+  // Register file system provider for binary Ion viewing/editing
+  context.subscriptions.push(
+    workspace.registerFileSystemProvider(
+      ION_BINARY_SCHEME,
+      new IonBinaryFSProvider(),
+    ),
+  );
 
   const serverOptions: ServerOptions = async () => {
     const options: ProcessOptions = {
@@ -45,10 +157,14 @@ export async function activate(context: ExtensionContext) {
     return startServer(process);
   };
 
+  const uriConverters = createUriConverters();
+  toServerPath = (uri: Uri) =>
+    fileUriToPath(uriConverters.code2Protocol(uri));
+
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ language: "ion" }],
     outputChannel: channel,
-    uriConverters: createUriConverters(),
+    uriConverters,
   };
 
   client = new LanguageClient(
@@ -58,6 +174,7 @@ export async function activate(context: ExtensionContext) {
     clientOptions,
   );
 
+  // --- Serialize Binary Ion command (existing) ---
   context.subscriptions.push(
     commands.registerCommand("covalence.serializeBinaryIon", async () => {
       if (!client) {
@@ -90,7 +207,138 @@ export async function activate(context: ExtensionContext) {
     }),
   );
 
+  // --- Convert to Ion 1.0 Binary ---
+  context.subscriptions.push(
+    commands.registerCommand("covalence.convertToIonBinary", async () => {
+      const editor = window.activeTextEditor;
+      if (!editor) {
+        window.showErrorMessage("No active editor.");
+        return;
+      }
+      if (editor.document.uri.scheme === ION_BINARY_SCHEME) {
+        window.showInformationMessage("This file is already binary Ion.");
+        return;
+      }
+      if (
+        editor.document.uri.scheme !== "file" ||
+        !editor.document.fileName.endsWith(".ion")
+      ) {
+        window.showErrorMessage(
+          "Convert to Binary is only available for text .ion files.",
+        );
+        return;
+      }
+
+      await clientReady;
+      const text = editor.document.getText();
+      const path = toServerPath(editor.document.uri);
+
+      const result: { error?: string } = await client!.sendRequest(
+        "covalence/encodeBinaryIon",
+        { path, text },
+      );
+
+      if (result.error) {
+        window.showErrorMessage(`Failed to encode: ${result.error}`);
+        return;
+      }
+
+      // Close text editor and reopen as binary Ion view
+      await commands.executeCommand("workbench.action.closeActiveEditor");
+      await openAsBinaryIon(editor.document.uri);
+
+      window.showInformationMessage("Converted to Ion 1.0 Binary.");
+    }),
+  );
+
+  // --- Convert to Ion 1.0 Text ---
+  context.subscriptions.push(
+    commands.registerCommand("covalence.convertToIonText", async () => {
+      const editor = window.activeTextEditor;
+      if (!editor) {
+        window.showErrorMessage("No active editor.");
+        return;
+      }
+
+      const uri = editor.document.uri;
+      let fileUri: Uri;
+
+      if (uri.scheme === ION_BINARY_SCHEME) {
+        fileUri = uri.with({ scheme: "file" });
+      } else if (uri.scheme === "file" && uri.path.endsWith(".ion")) {
+        const bytes = await workspace.fs.readFile(uri);
+        if (!isBinaryIon(bytes)) {
+          window.showInformationMessage("This file is already text Ion.");
+          return;
+        }
+        fileUri = uri;
+      } else {
+        window.showErrorMessage(
+          "Convert to Text is only available for binary .ion files.",
+        );
+        return;
+      }
+
+      if (!fileUri.path.endsWith(".ion")) {
+        window.showErrorMessage(
+          "Convert to Text is only available for .ion files.",
+        );
+        return;
+      }
+
+      // The editor shows decoded text Ion — write it directly to the file
+      const text = editor.document.getText();
+      await workspace.fs.writeFile(fileUri, new TextEncoder().encode(text));
+
+      // Close binary editor and reopen as text
+      await commands.executeCommand("workbench.action.closeActiveEditor");
+      const doc = await workspace.openTextDocument(fileUri);
+      await window.showTextDocument(doc);
+
+      window.showInformationMessage("Converted to Ion 1.0 Text.");
+    }),
+  );
+
+  // --- Intercept .10n and binary .ion file opens ---
+  const redirecting = new Set<string>();
+
+  context.subscriptions.push(
+    window.onDidChangeActiveTextEditor(async (editor) => {
+      if (!editor) return;
+      const doc = editor.document;
+      if (doc.uri.scheme !== "file") return;
+
+      const key = doc.uri.toString();
+      if (redirecting.has(key)) return;
+
+      let shouldRedirect = false;
+
+      if (doc.fileName.endsWith(".10n")) {
+        shouldRedirect = true;
+      } else if (doc.fileName.endsWith(".ion")) {
+        try {
+          const bytes = await workspace.fs.readFile(doc.uri);
+          shouldRedirect = isBinaryIon(bytes);
+        } catch {
+          // If we can't read the file, don't redirect
+        }
+      }
+
+      if (!shouldRedirect) return;
+      if (window.activeTextEditor !== editor) return;
+
+      redirecting.add(key);
+      try {
+        await commands.executeCommand("workbench.action.closeActiveEditor");
+        await openAsBinaryIon(doc.uri);
+      } finally {
+        redirecting.delete(key);
+      }
+    }),
+  );
+
   await client.start();
+  clientReadyResolve();
   channel.appendLine("Covalence LSP started.");
 }
 


### PR DESCRIPTION
## Summary

- Add LSP requests `covalence/decodeBinaryIon` and `covalence/encodeBinaryIon` that read/write binary Ion files via the WASI filesystem (path-based transport, no base64)
- Register an `ion-binary:` `FileSystemProvider` that transparently decodes binary Ion to prettyprinted text for editing, and re-encodes to binary on save
- Auto-redirect `.10n` files (always) and `.ion` files with a binary IVM header to the decoded text view via `onDidChangeActiveTextEditor`
- Add **Convert to Ion 1.0 Binary** command for text `.ion` files
- Add **Convert to Ion 1.0 Text** command for binary `.ion` files
- Fix race conditions in conversion commands using `revertAndCloseActiveEditor` to prevent save prompts from overwriting converted content
- Decode percent-encoded characters in URI-to-path conversion

## Test plan

- [ ] Open a `.10n` file — should auto-redirect to decoded prettyprinted text with Ion syntax highlighting
- [ ] Open a `.ion` file containing binary Ion (starts with IVM `0xE0 0x01 0x00 0xEA`) — should auto-redirect to decoded view
- [ ] Open a text `.ion` file — should open normally with no redirect
- [ ] Edit a binary Ion file (via decoded view) and save — file on disk should be valid binary Ion
- [ ] Run "Convert to Ion 1.0 Binary" on a text `.ion` file — file should become binary, editor should reopen in decoded view
- [ ] Run "Convert to Ion 1.0 Text" on a binary `.ion` file — file should become text, editor should reopen normally
- [ ] Verify formatting (Ctrl+Shift+F) and diagnostics work on decoded binary Ion documents
- [ ] Test with file paths containing spaces

https://claude.ai/code/session_011Eqx3KC6V6TYc3dvWBxRPe