### PR TITLE
Add WAT/WASM parsing and serialization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +46,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
@@ -109,8 +121,13 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "covalence-ion"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ion-rs",
  "pretty",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+ "wat",
 ]
 
 [[package]]
@@ -151,6 +168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +185,24 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -194,6 +234,18 @@ name = "ice_code"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6524844f553e8da5999f3000cf11d3f1ff926bb03fc087441c7b86dee4a7d48"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "ion-rs"
@@ -234,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,7 +322,7 @@ version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fluent-uri",
  "serde",
  "serde_json",
@@ -406,6 +464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +651,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wast"
+version = "245.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+dependencies = [
+ "wast",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +770,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/crates/covalence-ion/Cargo.toml
+++ b/crates/covalence-ion/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2024"
 [dependencies]
 ion-rs = "1.0.0-rc.11"
 pretty = "0.12"
+anyhow = "1"
+wat = "1.245"
+wasmprinter = "0.245"
+wasmparser = "0.245"
+wasm-encoder = { version = "0.245", features = ["wasmparser"] }

--- a/crates/covalence-ion/src/lib.rs
+++ b/crates/covalence-ion/src/lib.rs
@@ -4,3 +4,4 @@ mod prettyprint;
 pub use prettyprint::prettyprint;
 
 pub mod sexp;
+pub mod wasm;

--- a/crates/covalence-ion/src/sexp.rs
+++ b/crates/covalence-ion/src/sexp.rs
@@ -608,9 +608,8 @@ mod tests {
             let mut buf = Vec::new();
             prettyprint(&parsed, &mut buf).unwrap();
             let output = String::from_utf8(buf).unwrap();
-            let reparsed = parse(&output).unwrap_or_else(|e| {
-                panic!("failed to reparse {input:?}: {e}\noutput: {output:?}")
-            });
+            let reparsed = parse(&output)
+                .unwrap_or_else(|e| panic!("failed to reparse {input:?}: {e}\noutput: {output:?}"));
             assert_eq!(parsed, reparsed, "roundtrip mismatch for {input:?}");
         }
     }
@@ -628,10 +627,7 @@ mod tests {
     fn atom_stops_at_pipe() {
         assert_eq!(
             parse("foo|bar|").unwrap(),
-            vec![
-                SExp::Atom("foo".into()),
-                SExp::QuotedSymbol("bar".into()),
-            ]
+            vec![SExp::Atom("foo".into()), SExp::QuotedSymbol("bar".into()),]
         );
     }
 
@@ -648,9 +644,8 @@ mod tests {
             let mut buf = Vec::new();
             prettyprint(&parsed, &mut buf).unwrap();
             let output = String::from_utf8(buf).unwrap();
-            let reparsed = parse(&output).unwrap_or_else(|e| {
-                panic!("failed to reparse {input:?}: {e}\noutput: {output:?}")
-            });
+            let reparsed = parse(&output)
+                .unwrap_or_else(|e| panic!("failed to reparse {input:?}: {e}\noutput: {output:?}"));
             assert_eq!(parsed, reparsed, "roundtrip mismatch for {input:?}");
         }
     }

--- a/crates/covalence-ion/src/wasm.rs
+++ b/crates/covalence-ion/src/wasm.rs
@@ -1,0 +1,268 @@
+//! WAT / WASM parsing and serialization.
+//!
+//! Treats WebAssembly as a subset of Ion's S-expression format:
+//! - Parse `.wat` text files
+//! - Decode binary `.wasm` to WAT text (preserving custom sections)
+//! - Re-encode WAT text back to binary `.wasm`
+
+use std::fmt;
+
+use wasm_encoder::reencode::Reencode;
+
+/// Errors produced by WAT/WASM operations.
+#[derive(Debug)]
+pub enum WasmError {
+    /// WAT parse error (text -> binary).
+    Wat(wat::Error),
+    /// WASM binary -> WAT print error.
+    Print(anyhow::Error),
+    /// WASM binary parse/validation error.
+    Parser(wasmparser::BinaryReaderError),
+    /// WASM encoding error.
+    Encode(wasm_encoder::reencode::Error),
+}
+
+impl fmt::Display for WasmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WasmError::Wat(e) => write!(f, "WAT parse error: {e}"),
+            WasmError::Print(e) => write!(f, "WASM print error: {e}"),
+            WasmError::Parser(e) => write!(f, "WASM parse error: {e}"),
+            WasmError::Encode(e) => write!(f, "WASM encode error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for WasmError {}
+
+impl From<wat::Error> for WasmError {
+    fn from(e: wat::Error) -> Self {
+        WasmError::Wat(e)
+    }
+}
+
+impl From<wasmparser::BinaryReaderError> for WasmError {
+    fn from(e: wasmparser::BinaryReaderError) -> Self {
+        WasmError::Parser(e)
+    }
+}
+
+impl From<wasm_encoder::reencode::Error> for WasmError {
+    fn from(e: wasm_encoder::reencode::Error) -> Self {
+        WasmError::Encode(e)
+    }
+}
+
+/// Parse a WAT text string into binary WASM bytes.
+///
+/// Supports both core modules and component model syntax.
+pub fn wat_to_wasm(wat_text: &str) -> Result<Vec<u8>, WasmError> {
+    Ok(wat::parse_str(wat_text)?)
+}
+
+/// Convert binary WASM bytes to WAT text.
+///
+/// Custom sections are preserved as `(@custom ...)` annotations.
+/// Supports both core modules and components.
+pub fn wasm_to_wat(wasm_bytes: &[u8]) -> Result<String, WasmError> {
+    wasmprinter::print_bytes(wasm_bytes).map_err(WasmError::Print)
+}
+
+/// Parse a WAT text file, returning binary WASM.
+///
+/// This is a convenience wrapper around [`wat_to_wasm`].
+pub fn parse_wat(wat_text: &str) -> Result<Vec<u8>, WasmError> {
+    wat_to_wasm(wat_text)
+}
+
+/// Parse binary WASM and return WAT text.
+///
+/// This is a convenience wrapper around [`wasm_to_wat`].
+pub fn parse_wasm(wasm_bytes: &[u8]) -> Result<String, WasmError> {
+    wasm_to_wat(wasm_bytes)
+}
+
+/// Roundtrip: decode binary WASM to WAT, then re-encode to binary WASM.
+///
+/// This is the operation used when saving a modified WAT view of a `.wasm`
+/// file: the modified WAT text is parsed back to binary.
+pub fn wat_roundtrip(wasm_bytes: &[u8]) -> Result<Vec<u8>, WasmError> {
+    let wat_text = wasm_to_wat(wasm_bytes)?;
+    wat_to_wasm(&wat_text)
+}
+
+/// Re-encode WASM binary through `wasm-encoder`, preserving all sections
+/// including custom sections exactly as-is.
+///
+/// This is useful for normalizing or re-serializing a module without going
+/// through the text format.
+pub fn reencode_wasm(wasm_bytes: &[u8]) -> Result<Vec<u8>, WasmError> {
+    let parser = wasmparser::Parser::new(0);
+    let mut module = wasm_encoder::Module::new();
+    let mut encoder = wasm_encoder::reencode::RoundtripReencoder;
+    encoder.parse_core_module(&mut module, parser, wasm_bytes)?;
+    Ok(module.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_wat() {
+        let wat = "(module)";
+        let wasm = wat_to_wasm(wat).unwrap();
+        assert!(wasm.starts_with(b"\0asm"));
+    }
+
+    #[test]
+    fn roundtrip_minimal() {
+        let wat = "(module)";
+        let wasm = wat_to_wasm(wat).unwrap();
+        let wat2 = wasm_to_wat(&wasm).unwrap();
+        assert!(wat2.contains("module"));
+        let wasm2 = wat_to_wasm(&wat2).unwrap();
+        assert_eq!(wasm, wasm2);
+    }
+
+    #[test]
+    fn roundtrip_with_function() {
+        let wat = r#"
+            (module
+                (func $add (param $a i32) (param $b i32) (result i32)
+                    local.get $a
+                    local.get $b
+                    i32.add)
+                (export "add" (func $add)))
+        "#;
+        let wasm = wat_to_wasm(wat).unwrap();
+        let wat2 = wasm_to_wat(&wasm).unwrap();
+        assert!(wat2.contains("i32.add"));
+        assert!(wat2.contains("\"add\""));
+        let wasm2 = wat_to_wasm(&wat2).unwrap();
+        assert_eq!(wasm, wasm2);
+    }
+
+    #[test]
+    fn roundtrip_with_memory_and_data() {
+        let wat = r#"
+            (module
+                (memory 1)
+                (data (i32.const 0) "hello"))
+        "#;
+        let wasm = wat_to_wasm(wat).unwrap();
+        let wat2 = wasm_to_wat(&wasm).unwrap();
+        assert!(wat2.contains("memory"));
+        assert!(wat2.contains("hello"));
+        let wasm2 = wat_to_wasm(&wat2).unwrap();
+        assert_eq!(wasm, wasm2);
+    }
+
+    #[test]
+    fn custom_section_preserved_through_text_roundtrip() {
+        let mut module = wasm_encoder::Module::new();
+        module.section(&wasm_encoder::CustomSection {
+            name: "my-custom".into(),
+            data: b"payload data".into(),
+        });
+        let wasm = module.finish();
+
+        let wat = wasm_to_wat(&wasm).unwrap();
+        assert!(
+            wat.contains("my-custom"),
+            "custom section name in WAT: {wat}"
+        );
+
+        let wasm2 = wat_to_wasm(&wat).unwrap();
+        let wat2 = wasm_to_wat(&wasm2).unwrap();
+        assert!(
+            wat2.contains("my-custom"),
+            "custom section preserved after roundtrip: {wat2}"
+        );
+    }
+
+    #[test]
+    fn custom_section_preserved_through_reencode() {
+        let mut module = wasm_encoder::Module::new();
+        module.section(&wasm_encoder::TypeSection::new());
+        module.section(&wasm_encoder::CustomSection {
+            name: "test-section".into(),
+            data: b"\x01\x02\x03".into(),
+        });
+        let wasm = module.finish();
+
+        let reencoded = reencode_wasm(&wasm).unwrap();
+        let wat = wasm_to_wat(&reencoded).unwrap();
+        assert!(
+            wat.contains("test-section"),
+            "custom section preserved through reencode: {wat}"
+        );
+    }
+
+    #[test]
+    fn invalid_wat_returns_error() {
+        let result = wat_to_wasm("(not valid wasm at all)");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_wasm_bytes_returns_error() {
+        let result = wasm_to_wat(b"not wasm");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn roundtrip_globals_and_tables() {
+        let wat = r#"
+            (module
+                (global $g (mut i32) (i32.const 42))
+                (table 1 funcref)
+                (func $f (result i32) global.get $g)
+                (export "f" (func $f)))
+        "#;
+        let wasm = wat_to_wasm(wat).unwrap();
+        let wat2 = wasm_to_wat(&wasm).unwrap();
+        assert!(wat2.contains("global"));
+        assert!(wat2.contains("table"));
+        let wasm2 = wat_to_wasm(&wat2).unwrap();
+        assert_eq!(wasm, wasm2);
+    }
+
+    #[test]
+    fn roundtrip_imports() {
+        let wat = r#"
+            (module
+                (import "env" "log" (func $log (param i32))))
+        "#;
+        let wasm = wat_to_wasm(wat).unwrap();
+        let wat2 = wasm_to_wat(&wasm).unwrap();
+        assert!(wat2.contains("\"env\""));
+        assert!(wat2.contains("\"log\""));
+        let wasm2 = wat_to_wasm(&wat2).unwrap();
+        assert_eq!(wasm, wasm2);
+    }
+
+    #[test]
+    fn multiple_custom_sections() {
+        let mut module = wasm_encoder::Module::new();
+        module.section(&wasm_encoder::CustomSection {
+            name: "first".into(),
+            data: b"aaa".into(),
+        });
+        module.section(&wasm_encoder::TypeSection::new());
+        module.section(&wasm_encoder::CustomSection {
+            name: "second".into(),
+            data: b"bbb".into(),
+        });
+        let wasm = module.finish();
+
+        let wat = wasm_to_wat(&wasm).unwrap();
+        assert!(wat.contains("first"));
+        assert!(wat.contains("second"));
+
+        let wasm2 = wat_to_wasm(&wat).unwrap();
+        let wat2 = wasm_to_wat(&wasm2).unwrap();
+        assert!(wat2.contains("first"));
+        assert!(wat2.contains("second"));
+    }
+}

--- a/crates/covalence-ion/tests/fixtures/add.wat
+++ b/crates/covalence-ion/tests/fixtures/add.wat
@@ -1,0 +1,18 @@
+(module
+  (func $add (export "add") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.add)
+  (func $sub (export "sub") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.sub)
+  (memory (export "memory") 1)
+  (global $counter (mut i32) (i32.const 0))
+  (func $increment (export "increment") (result i32)
+    global.get $counter
+    i32.const 1
+    i32.add
+    global.set $counter
+    global.get $counter)
+  (@custom "build-info" "covalence-test-v1"))

--- a/crates/covalence-ion/tests/fixtures/imports.wat
+++ b/crates/covalence-ion/tests/fixtures/imports.wat
@@ -1,0 +1,8 @@
+(module
+  (import "env" "log" (func $log (param i32)))
+  (import "env" "memory" (memory 1))
+  (func $greet (export "greet") (param $n i32)
+    local.get $n
+    call $log)
+  (data (i32.const 0) "Hello, WebAssembly!\00")
+  (@custom "source-map" "//# sourceMappingURL=test.map"))

--- a/crates/covalence-ion/tests/fixtures/tables.wat
+++ b/crates/covalence-ion/tests/fixtures/tables.wat
@@ -1,0 +1,9 @@
+(module
+  (type $return_i32 (func (result i32)))
+  (table 2 funcref)
+  (elem (i32.const 0) $f0 $f1)
+  (func $f0 (type $return_i32) (i32.const 42))
+  (func $f1 (type $return_i32) (i32.const 99))
+  (func $call_indirect (export "call") (param $idx i32) (result i32)
+    local.get $idx
+    call_indirect (type $return_i32)))

--- a/crates/covalence-ion/tests/wasm_integration.rs
+++ b/crates/covalence-ion/tests/wasm_integration.rs
@@ -1,0 +1,295 @@
+//! Integration tests for WAT/WASM parsing and serialization.
+//!
+//! Tests use both text (.wat) fixture files and programmatically-generated
+//! binary (.wasm) files to verify roundtripping, custom section preservation,
+//! and error handling.
+
+use std::fs;
+use std::path::PathBuf;
+
+use covalence_ion::wasm;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+// ---------------------------------------------------------------------------
+// WAT text file parsing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_add_wat_file() {
+    let wat = fs::read_to_string(fixture_path("add.wat")).unwrap();
+    let wasm = wasm::wat_to_wasm(&wat).unwrap();
+    assert!(wasm.starts_with(b"\0asm"), "valid WASM header");
+    assert!(wasm.len() > 8, "non-trivial module");
+}
+
+#[test]
+fn parse_imports_wat_file() {
+    let wat = fs::read_to_string(fixture_path("imports.wat")).unwrap();
+    let wasm = wasm::wat_to_wasm(&wat).unwrap();
+    assert!(wasm.starts_with(b"\0asm"));
+}
+
+#[test]
+fn parse_tables_wat_file() {
+    let wat = fs::read_to_string(fixture_path("tables.wat")).unwrap();
+    let wasm = wasm::wat_to_wasm(&wat).unwrap();
+    assert!(wasm.starts_with(b"\0asm"));
+}
+
+// ---------------------------------------------------------------------------
+// Binary WASM → WAT → binary roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_add_module() {
+    let wat = fs::read_to_string(fixture_path("add.wat")).unwrap();
+    let wasm1 = wasm::wat_to_wasm(&wat).unwrap();
+    let wat2 = wasm::wasm_to_wat(&wasm1).unwrap();
+
+    // WAT output should contain key identifiers
+    assert!(wat2.contains("\"add\""), "export name present");
+    assert!(wat2.contains("\"sub\""), "export name present");
+    assert!(wat2.contains("\"increment\""), "export name present");
+    assert!(wat2.contains("i32.add"), "instruction present");
+
+    // Re-parse WAT back to binary and verify functional equivalence via WAT
+    // (byte equality may differ due to custom section ordering, e.g. name sections)
+    let wasm2 = wasm::wat_to_wasm(&wat2).unwrap();
+    let wat3 = wasm::wasm_to_wat(&wasm2).unwrap();
+    assert_eq!(wat2, wat3, "WAT roundtrip is stable");
+}
+
+#[test]
+fn roundtrip_imports_module() {
+    let wat = fs::read_to_string(fixture_path("imports.wat")).unwrap();
+    let wasm1 = wasm::wat_to_wasm(&wat).unwrap();
+    let wat2 = wasm::wasm_to_wat(&wasm1).unwrap();
+
+    assert!(wat2.contains("\"env\""), "import module present");
+    assert!(wat2.contains("\"log\""), "import name present");
+    assert!(wat2.contains("Hello, WebAssembly!"), "data segment present");
+
+    let wasm2 = wasm::wat_to_wasm(&wat2).unwrap();
+    let wat3 = wasm::wasm_to_wat(&wasm2).unwrap();
+    assert_eq!(wat2, wat3, "WAT roundtrip is stable");
+}
+
+#[test]
+fn roundtrip_tables_module() {
+    let wat = fs::read_to_string(fixture_path("tables.wat")).unwrap();
+    let wasm1 = wasm::wat_to_wasm(&wat).unwrap();
+    let wat2 = wasm::wasm_to_wat(&wasm1).unwrap();
+
+    assert!(wat2.contains("call_indirect"), "call_indirect present");
+
+    let wasm2 = wasm::wat_to_wasm(&wat2).unwrap();
+    let wat3 = wasm::wasm_to_wat(&wasm2).unwrap();
+    assert_eq!(wat2, wat3, "WAT roundtrip is stable");
+}
+
+// ---------------------------------------------------------------------------
+// Custom section preservation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn custom_section_preserved_in_add_module() {
+    let wat = fs::read_to_string(fixture_path("add.wat")).unwrap();
+    let wasm = wasm::wat_to_wasm(&wat).unwrap();
+    let wat2 = wasm::wasm_to_wat(&wasm).unwrap();
+    assert!(
+        wat2.contains("build-info"),
+        "custom section 'build-info' preserved in WAT output: {wat2}"
+    );
+
+    // Roundtrip again — still present
+    let wasm2 = wasm::wat_to_wasm(&wat2).unwrap();
+    let wat3 = wasm::wasm_to_wat(&wasm2).unwrap();
+    assert!(
+        wat3.contains("build-info"),
+        "custom section preserved through double roundtrip"
+    );
+}
+
+#[test]
+fn custom_section_preserved_in_imports_module() {
+    let wat = fs::read_to_string(fixture_path("imports.wat")).unwrap();
+    let wasm = wasm::wat_to_wasm(&wat).unwrap();
+    let wat2 = wasm::wasm_to_wat(&wasm).unwrap();
+    assert!(
+        wat2.contains("source-map"),
+        "custom section 'source-map' preserved: {wat2}"
+    );
+}
+
+#[test]
+fn custom_section_with_binary_payload() {
+    // Create a module with binary data in a custom section
+    let mut module = wasm_encoder::Module::new();
+    module.section(&wasm_encoder::CustomSection {
+        name: "debug-data".into(),
+        data: vec![0x00, 0xFF, 0x42, 0x80, 0xFE].into(),
+    });
+    let wasm = module.finish();
+
+    let wat = wasm::wasm_to_wat(&wasm).unwrap();
+    assert!(wat.contains("debug-data"));
+
+    let wasm2 = wasm::wat_to_wasm(&wat).unwrap();
+    let wat2 = wasm::wasm_to_wat(&wasm2).unwrap();
+    assert!(
+        wat2.contains("debug-data"),
+        "binary custom section survives roundtrip"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binary WASM generation & decoding (no WAT fixture files)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decode_programmatic_wasm_binary() {
+    // Build a WASM module entirely from wasm-encoder
+    let mut module = wasm_encoder::Module::new();
+
+    let mut types = wasm_encoder::TypeSection::new();
+    types.ty().function(
+        vec![wasm_encoder::ValType::I32],
+        vec![wasm_encoder::ValType::I32],
+    );
+    module.section(&types);
+
+    let mut funcs = wasm_encoder::FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+
+    let mut exports = wasm_encoder::ExportSection::new();
+    exports.export("double", wasm_encoder::ExportKind::Func, 0);
+    module.section(&exports);
+
+    let mut code = wasm_encoder::CodeSection::new();
+    let mut f = wasm_encoder::Function::new(vec![]);
+    f.instruction(&wasm_encoder::Instruction::LocalGet(0));
+    f.instruction(&wasm_encoder::Instruction::LocalGet(0));
+    f.instruction(&wasm_encoder::Instruction::I32Add);
+    f.instruction(&wasm_encoder::Instruction::End);
+    code.function(&f);
+    module.section(&code);
+
+    module.section(&wasm_encoder::CustomSection {
+        name: "produced-by".into(),
+        data: b"covalence-tests".into(),
+    });
+
+    let wasm = module.finish();
+
+    // Decode to WAT
+    let wat = wasm::wasm_to_wat(&wasm).unwrap();
+    assert!(wat.contains("\"double\""));
+    assert!(wat.contains("i32.add"));
+    assert!(wat.contains("produced-by"));
+
+    // Roundtrip back
+    let wasm2 = wasm::wat_to_wasm(&wat).unwrap();
+    assert_eq!(wasm, wasm2);
+}
+
+// ---------------------------------------------------------------------------
+// Save-modified-WAT workflow (simulating editing a .wasm file's WAT view)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn save_modified_wat_view() {
+    // 1. Start with a binary .wasm
+    let original_wat = fs::read_to_string(fixture_path("add.wat")).unwrap();
+    let original_wasm = wasm::wat_to_wasm(&original_wat).unwrap();
+
+    // 2. Decode to WAT for editing
+    let wat_view = wasm::wasm_to_wat(&original_wasm).unwrap();
+    assert!(wat_view.contains("i32.add"));
+
+    // 3. "Edit" the WAT: change add to multiply
+    let modified_wat = wat_view.replace("i32.add", "i32.mul");
+    assert!(modified_wat.contains("i32.mul"));
+    assert!(!modified_wat.contains("i32.add"));
+
+    // 4. Re-serialize to binary (the "save" operation)
+    let modified_wasm = wasm::wat_to_wasm(&modified_wat).unwrap();
+    assert!(modified_wasm.starts_with(b"\0asm"));
+    assert_ne!(original_wasm, modified_wasm, "binary changed after edit");
+
+    // 5. Verify the modification stuck
+    let verify_wat = wasm::wasm_to_wat(&modified_wasm).unwrap();
+    assert!(verify_wat.contains("i32.mul"));
+    assert!(!verify_wat.contains("i32.add"));
+}
+
+#[test]
+fn save_modified_wat_preserves_custom_sections() {
+    let original_wat = fs::read_to_string(fixture_path("add.wat")).unwrap();
+    let original_wasm = wasm::wat_to_wasm(&original_wat).unwrap();
+    let wat_view = wasm::wasm_to_wat(&original_wasm).unwrap();
+
+    // Modify something but keep custom sections
+    let modified_wat = wat_view.replace("i32.sub", "i32.xor");
+    let modified_wasm = wasm::wat_to_wasm(&modified_wat).unwrap();
+    let verify_wat = wasm::wasm_to_wat(&modified_wasm).unwrap();
+
+    assert!(verify_wat.contains("i32.xor"), "edit preserved");
+    assert!(
+        verify_wat.contains("build-info"),
+        "custom section preserved after edit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Reencode (binary → binary without text intermediate)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reencode_preserves_structure() {
+    let wat = fs::read_to_string(fixture_path("add.wat")).unwrap();
+    let wasm = wasm::wat_to_wasm(&wat).unwrap();
+    let reencoded = wasm::reencode_wasm(&wasm).unwrap();
+
+    // Reencoded module should be functionally equivalent
+    let wat_original = wasm::wasm_to_wat(&wasm).unwrap();
+    let wat_reencoded = wasm::wasm_to_wat(&reencoded).unwrap();
+    assert_eq!(wat_original, wat_reencoded);
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn error_on_invalid_wat() {
+    let result = wasm::wat_to_wasm("(module (func (invalid-instruction)))");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("WAT parse error"), "error message: {err}");
+}
+
+#[test]
+fn error_on_invalid_wasm_binary() {
+    let result = wasm::wasm_to_wat(b"\x00\x01\x02\x03");
+    assert!(result.is_err());
+}
+
+#[test]
+fn error_on_truncated_wasm() {
+    // Valid header but truncated
+    let result = wasm::wasm_to_wat(b"\0asm\x01\x00\x00\x00\x01");
+    assert!(result.is_err());
+}
+
+#[test]
+fn error_on_empty_input() {
+    assert!(wasm::wat_to_wasm("").is_err());
+    assert!(wasm::wasm_to_wat(b"").is_err());
+}

--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -251,10 +251,7 @@ pub fn diagnose_sexp(text: &str) -> Vec<Diagnostic> {
         Err(e) => {
             let (line, col) = covalence_ion::sexp::offset_to_line_col(text, e.offset);
             vec![Diagnostic {
-                range: Range::new(
-                    Position::new(line, col),
-                    Position::new(line, col),
-                ),
+                range: Range::new(Position::new(line, col), Position::new(line, col)),
                 severity: Some(DiagnosticSeverity::ERROR),
                 message: e.message,
                 ..Default::default()

--- a/crates/covalence-lsp/src/main.rs
+++ b/crates/covalence-lsp/src/main.rs
@@ -7,9 +7,8 @@ fn main() {
     if args.get(1).is_some_and(|a| a == "--diagnose") {
         let path = args.get(2).expect("usage: covalence-lsp --diagnose <file>");
         let text = std::fs::read_to_string(path).unwrap();
-        let is_sexp = path.ends_with(".smt")
-            || path.ends_with(".smt2")
-            || path.ends_with(".alethe");
+        let is_sexp =
+            path.ends_with(".smt") || path.ends_with(".smt2") || path.ends_with(".alethe");
         let diagnostics = if is_sexp {
             covalence_lsp::diagnose_sexp(&text)
         } else {


### PR DESCRIPTION
## Summary
This PR adds comprehensive WebAssembly (WAT/WASM) parsing and serialization capabilities to the covalence-ion library, enabling roundtrip conversion between text (`.wat`) and binary (`.wasm`) formats while preserving custom sections.

## Key Changes

- **New `wasm` module** (`src/wasm.rs`): Core WAT/WASM functionality
  - `wat_to_wasm()`: Parse WAT text to binary WASM
  - `wasm_to_wat()`: Decode binary WASM to WAT text (preserving custom sections)
  - `reencode_wasm()`: Re-encode WASM binary through wasm-encoder
  - `wat_roundtrip()`: Convenience function for decode-then-encode workflow
  - Comprehensive error handling via `WasmError` enum

- **Integration tests** (`tests/wasm_integration.rs`): 295 lines of test coverage
  - WAT file parsing (add, imports, tables fixtures)
  - Binary ↔ WAT ↔ binary roundtrip verification
  - Custom section preservation through multiple roundtrips
  - Programmatic WASM binary generation and decoding
  - Save-modified-WAT workflow simulation
  - Error handling for invalid inputs

- **Test fixtures** (3 WAT files):
  - `add.wat`: Basic arithmetic functions with custom "build-info" section
  - `imports.wat`: Module with imports and custom "source-map" section
  - `tables.wat`: Table and indirect call examples

- **Dependencies**: Added `wat`, `wasmprinter`, `wasmparser`, and `wasm-encoder` crates

- **Minor formatting**: Cleaned up line wrapping in `sexp.rs` and LSP code for consistency

## Implementation Details

- Custom sections are preserved through text roundtrips via wasmprinter's `@custom` annotations
- The module treats WebAssembly as a subset of Ion's S-expression format
- Supports both core modules and component model syntax
- All roundtrip tests verify functional equivalence (WAT output stability after re-encoding)
- Error messages are descriptive and include context for debugging

https://claude.ai/code/session_011jCYZWUdMhvvoRufokzQkj