### PR TITLE
Display .wasm files as WAT text in the editor

### DIFF
--- a/crates/covalence-lsp/src/lib.rs
+++ b/crates/covalence-lsp/src/lib.rs
@@ -85,6 +85,34 @@ impl Server {
                 };
                 Some(Response::new_ok(req.id.clone(), result))
             }
+            "covalence/decodeWasm" => {
+                let result = match req.params.get("path").and_then(|v| v.as_str()) {
+                    Some(path) => decode_wasm_file(path),
+                    None => {
+                        return Some(Response::new_err(
+                            req.id.clone(),
+                            lsp_server::ErrorCode::InvalidParams as i32,
+                            "missing or invalid \"path\" parameter".to_owned(),
+                        ));
+                    }
+                };
+                Some(Response::new_ok(req.id.clone(), result))
+            }
+            "covalence/encodeWasm" => {
+                let path = req.params.get("path").and_then(|v| v.as_str());
+                let text = req.params.get("text").and_then(|v| v.as_str());
+                let result = match (path, text) {
+                    (Some(path), Some(text)) => encode_wasm_file(path, text),
+                    _ => {
+                        return Some(Response::new_err(
+                            req.id.clone(),
+                            lsp_server::ErrorCode::InvalidParams as i32,
+                            "missing or invalid \"path\" and/or \"text\" parameter".to_owned(),
+                        ));
+                    }
+                };
+                Some(Response::new_ok(req.id.clone(), result))
+            }
             lsp_types::request::Formatting::METHOD => {
                 let params: DocumentFormattingParams =
                     match serde_json::from_value(req.params.clone()) {
@@ -212,6 +240,31 @@ fn encode_binary_ion_file(path: &str, text: &str) -> serde_json::Value {
             Err(e) => serde_json::json!({ "error": format!("binary encode error: {e}") }),
         },
         Err(e) => serde_json::json!({ "error": format!("Ion parse error: {e}") }),
+    }
+}
+
+fn decode_wasm_file(path: &str) -> serde_json::Value {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => return serde_json::json!({ "error": format!("file read error: {e}") }),
+    };
+
+    match covalence_ion::wasm::wasm_to_wat(&bytes) {
+        Ok(text) => {
+            let text = if text.is_empty() { text } else { text + "\n" };
+            serde_json::json!({ "text": text })
+        }
+        Err(e) => serde_json::json!({ "error": format!("{e}") }),
+    }
+}
+
+fn encode_wasm_file(path: &str, text: &str) -> serde_json::Value {
+    match covalence_ion::wasm::wat_to_wasm(text) {
+        Ok(bytes) => match std::fs::write(path, &bytes) {
+            Ok(()) => serde_json::json!({}),
+            Err(e) => serde_json::json!({ "error": format!("file write error: {e}") }),
+        },
+        Err(e) => serde_json::json!({ "error": format!("{e}") }),
     }
 }
 

--- a/extensions/covalence-vscode/package.json
+++ b/extensions/covalence-vscode/package.json
@@ -33,6 +33,12 @@
         "aliases": ["Alethe"],
         "extensions": [".alethe"],
         "configuration": "./smt-language-configuration.json"
+      },
+      {
+        "id": "wat",
+        "aliases": ["WebAssembly Text", "WAT"],
+        "extensions": [".wat"],
+        "configuration": "./smt-language-configuration.json"
       }
     ],
     "grammars": [
@@ -48,6 +54,11 @@
       },
       {
         "language": "alethe",
+        "scopeName": "source.smt",
+        "path": "./syntaxes/smt.tmLanguage.json"
+      },
+      {
+        "language": "wat",
         "scopeName": "source.smt",
         "path": "./syntaxes/smt.tmLanguage.json"
       }

--- a/extensions/covalence-vscode/src/extension.ts
+++ b/extensions/covalence-vscode/src/extension.ts
@@ -25,6 +25,7 @@ import {
 } from "@vscode/wasm-wasi-lsp";
 
 const ION_BINARY_SCHEME = "ion-binary";
+const WASM_BINARY_SCHEME = "wasm-binary";
 
 // Ion Version Marker for Ion 1.0: 0xE0 0x01 0x00 0xEA
 function isBinaryIon(bytes: Uint8Array): boolean {
@@ -110,6 +111,72 @@ class IonBinaryFSProvider implements FileSystemProvider {
   }
 }
 
+class WasmBinaryFSProvider implements FileSystemProvider {
+  private _emitter = new EventEmitter<FileChangeEvent[]>();
+  readonly onDidChangeFile = this._emitter.event;
+
+  watch(): Disposable {
+    return new Disposable(() => {});
+  }
+
+  async stat(uri: Uri): Promise<FileStat> {
+    const realUri = uri.with({ scheme: "file" });
+    return workspace.fs.stat(realUri);
+  }
+
+  readDirectory(): Thenable<[string, FileType][]> {
+    throw new Error("Not supported");
+  }
+
+  createDirectory(): void {
+    throw new Error("Not supported");
+  }
+
+  async readFile(uri: Uri): Promise<Uint8Array> {
+    await clientReady;
+    const path = toServerPath(uri.with({ scheme: "file" }));
+
+    const result: { text?: string; error?: string } =
+      await client!.sendRequest("covalence/decodeWasm", { path });
+
+    if (result.error) {
+      throw new Error(`Failed to decode WASM: ${result.error}`);
+    }
+
+    return new TextEncoder().encode(result.text || "");
+  }
+
+  async writeFile(uri: Uri, content: Uint8Array): Promise<void> {
+    await clientReady;
+    const path = toServerPath(uri.with({ scheme: "file" }));
+    const text = new TextDecoder().decode(content);
+
+    const result: { error?: string } = await client!.sendRequest(
+      "covalence/encodeWasm",
+      { path, text },
+    );
+
+    if (result.error) {
+      throw new Error(`Failed to encode WASM: ${result.error}`);
+    }
+  }
+
+  delete(): void {
+    throw new Error("Not supported");
+  }
+
+  rename(): void {
+    throw new Error("Not supported");
+  }
+}
+
+async function openAsWasmBinary(fileUri: Uri): Promise<void> {
+  const wasmUri = fileUri.with({ scheme: WASM_BINARY_SCHEME });
+  const doc = await workspace.openTextDocument(wasmUri);
+  await languages.setTextDocumentLanguage(doc, "wat");
+  await window.showTextDocument(doc);
+}
+
 async function openAsBinaryIon(fileUri: Uri): Promise<void> {
   const ionUri = fileUri.with({ scheme: ION_BINARY_SCHEME });
   const doc = await workspace.openTextDocument(ionUri);
@@ -121,11 +188,15 @@ export async function activate(context: ExtensionContext) {
   const channel = window.createOutputChannel("Covalence LSP");
   const wasm: Wasm = await Wasm.load();
 
-  // Register file system provider for binary Ion viewing/editing
+  // Register file system providers for binary viewing/editing
   context.subscriptions.push(
     workspace.registerFileSystemProvider(
       ION_BINARY_SCHEME,
       new IonBinaryFSProvider(),
+    ),
+    workspace.registerFileSystemProvider(
+      WASM_BINARY_SCHEME,
+      new WasmBinaryFSProvider(),
     ),
   );
 
@@ -166,6 +237,7 @@ export async function activate(context: ExtensionContext) {
       { language: "ion" },
       { language: "smt" },
       { language: "alethe" },
+      { language: "wat" },
     ],
     outputChannel: channel,
     uriConverters,
@@ -336,15 +408,27 @@ export async function activate(context: ExtensionContext) {
         }
       }
 
-      if (!shouldRedirect) return;
-      if (window.activeTextEditor !== editor) return;
+      if (shouldRedirect) {
+        if (window.activeTextEditor !== editor) return;
+        redirecting.add(key);
+        try {
+          await commands.executeCommand("workbench.action.closeActiveEditor");
+          await openAsBinaryIon(doc.uri);
+        } finally {
+          redirecting.delete(key);
+        }
+        return;
+      }
 
-      redirecting.add(key);
-      try {
-        await commands.executeCommand("workbench.action.closeActiveEditor");
-        await openAsBinaryIon(doc.uri);
-      } finally {
-        redirecting.delete(key);
+      if (doc.fileName.endsWith(".wasm")) {
+        if (window.activeTextEditor !== editor) return;
+        redirecting.add(key);
+        try {
+          await commands.executeCommand("workbench.action.closeActiveEditor");
+          await openAsWasmBinary(doc.uri);
+        } finally {
+          redirecting.delete(key);
+        }
       }
     }),
   );


### PR DESCRIPTION
Add a WasmBinaryFSProvider (mirroring the existing IonBinaryFSProvider)
that decodes binary .wasm files to WAT text via new LSP requests
(covalence/decodeWasm, covalence/encodeWasm). The extension intercepts
.wasm file opens and redirects them through the wasm-binary:// scheme,
so users see editable WAT instead of "binary file" errors.

https://claude.ai/code/session_016dKD2PcggkvDN82raA9pPL