### PR TITLE
docs: refactor current-state documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,112 @@
 # Covalence
 
-An experimental LCF-style theorem prover and VCS using WASM components.
-Metatheory is the default mode; the kernel extends itself by proof
-rather than by trust.
+Covalence is an experimental monorepo for content-addressed storage, proof and
+logic tooling, WASM execution, and multiple user surfaces over that substrate.
+The repository currently contains:
 
-**Read first:** [`docs/README.md`](./docs/README.md) for the docs map.
+- a Rust CLI and local server,
+- a browser UI and a VS Code extension,
+- Python and TypeScript client libraries,
+- several coexisting prover / logic lines (`covalence-kernel`,
+  `covalence-pure`, `covalence-hol`),
+- import and certificate tooling for OpenTheory, SMT/Alethe, SAT, egglog,
+  Metamath, Lean exports, and SpecTec/WASM assets.
 
-Recommended path:
-[`docs/c4.md`](./docs/c4.md) (repo architecture map) →
-[`docs/where-we-are.md`](./docs/where-we-are.md) (current status) →
-[`docs/VISION.md`](./docs/VISION.md) (10-minute overview) →
-[`ARCHITECTURE.md`](./ARCHITECTURE.md) (canonical philosophy) →
-[`AGENTS.md`](./AGENTS.md) (implementation invariants).
+`covalence-pure` has not been removed. What was removed is an older shell-side
+adapter path (`HolPrim`) in `covalence-shell`; the Pure and HOL crates remain
+in the tree.
 
-## Repository Layout
+If you want the implementation map rather than the long-term philosophy, start
+with [`docs/where-we-are.md`](./docs/where-we-are.md) and
+[`docs/c4.md`](./docs/c4.md).
 
-- `crates/` — Rust workspace with CLI/server/editor surfaces, kernel and prover
-  experiments, substrate crates, and wrapper crates
+## Docs
+
+- [`docs/README.md`](./docs/README.md) — documentation index
+- [`docs/where-we-are.md`](./docs/where-we-are.md) — current codebase snapshot
+- [`docs/c4.md`](./docs/c4.md) — runtime and repo architecture map
+- [`docs/institution-map.md`](./docs/institution-map.md) — logic / proof-format /
+  translation landscape
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — target architecture and invariants
+- [`AGENTS.md`](./AGENTS.md) — implementation constraints for trusted-core work
+
+## Repo Shape
+
+- `crates/` — Rust workspace members
 - `apps/covalence-web/` — SvelteKit browser UI
-- `packages/` — shared TypeScript packages
-- `extensions/covalence-vscode/` — VS Code extension
-- `docs/` — current-state docs, proposal docs, and planning/history
-- `assets/`, `tests/`, `test-workbench/` — fixtures, samples, and test scaffolding
+- `packages/` — TypeScript packages (`covalence-client`, `covalence-ui`,
+  `covalence-wasm-js`)
+- `extensions/covalence-vscode/` — VS Code extension for `.cov`, SMT-LIB,
+  Alethe, and WAT
+- `docs/` — current-state docs, design proposals, and historical notes
+- `assets/`, `tests/`, `test-workbench/` — fixtures and integration scaffolding
 
 ## Prerequisites
 
-- [Rust stable ≥1.94.1](https://rustup.rs/) with `wasm32-wasip1-threads` and `wasm32-unknown-unknown` targets
+- Rust stable with `wasm32-wasip1-threads` and `wasm32-unknown-unknown`
 - [Bun](https://bun.sh/)
-- wasm-pack, wasm-bindgen-cli, binaryen (wasm-opt)
+- `wasm-pack`, `wasm-bindgen-cli`, `binaryen`
+- Python + `maturin` if you are building `crates/covalence-python`
 
-## Quick Start
+## Build And Run
 
 ```sh
-bun install            # install JS dependencies
-bun run build          # full build: native (debug) + WASM + esbuild
-cargo test             # run Rust tests
-cov repl               # interactive S-expression REPL
-cov serve --open       # start server, open browser
+bun install
+bun run build:serve
+cargo test
+cov repl
+cov serve --open
 ```
+
+Useful variants:
+
+```sh
+bun run build             # native cov + VS Code WASM extension assets
+bun run build:web          # build the Svelte app only
+bun run build:serve        # build web assets + native cov binary
+bun run code:browser       # launch the VS Code web extension flow
+bun run code:desktop       # launch the desktop VS Code extension flow
+bun run build:python       # build/install the Python bindings with maturin
+```
+
+## Main Commands
+
+The `cov` binary currently exposes these top-level commands:
+
+- `cov repl` — local or remote content-store REPL
+- `cov serve` — HTTP API + WebSocket REPL + optional static web UI
+- `cov cog` — git/object-store tooling (`hash-blob`, `clone`, Linux `mount`)
+- `cov hol check` — check OpenTheory article files against `covalence-hol`
+- `cov lsp` — start the language server used by the editor tooling
+
+## Frontend Development
+
+For local web work:
+
+```sh
+cov serve --api
+bun run dev:web
+```
+
+The Vite dev server serves the Svelte app and proxies `/api` to the local
+backend. The built web app currently includes:
+
+- a REPL page backed by the WebSocket API,
+- an object viewer for blobs and trees,
+- a `cov:graph` viewer page.
+
+## Testing
+
+There is no single top-level JS test command yet. Use the commands that match
+the surface you changed:
+
+- `cargo test`
+- `bun run test:ui`
+- `bun run test:wasm-js`
+- `bun run test:python`
+
+Contributions are accepted under the same dual offering. Vendored third-party
+code keeps its upstream license and is documented locally where relevant.
 
 ## License
 
@@ -48,8 +117,3 @@ possible. You may use it under either:
 - the [CC0 1.0 Universal](./LICENSE-CC0) public-domain dedication (`CC0-1.0`).
 
 SPDX expression: `0BSD OR CC0-1.0`.
-
-Contributions are accepted under the same dual offering — see
-[`CONTRIBUTING.md`](./CONTRIBUTING.md). Vendored third-party code keeps
-its upstream license and is documented locally (e.g.
-[`assets/spectec/README.md`](./assets/spectec/README.md)).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,67 +1,76 @@
 # Documentation Map
 
-This repository has three different kinds of documentation:
+This directory now has three clearly different jobs:
 
-- **Canonical vision**: what Covalence is trying to become.
-- **Current-state docs**: what is actually in the tree today.
-- **Proposal docs**: candidate directions that are still under debate.
+- describe the code that exists today,
+- describe the target architecture and invariants,
+- keep proposals and historical material without pretending they are current.
 
-This page is the index for all three so contributors do not have to infer which
-documents are normative.
+Use this page to avoid mixing those layers up.
 
-## Start here
+## Start Here
 
 | If you need... | Read |
 |---|---|
-| A quick map of the system and repo | [`c4.md`](./c4.md) |
-| The multi-logic / multi-format zoo in one vocabulary | [`institution-map.md`](./institution-map.md) |
-| The short conceptual overview | [`VISION.md`](./VISION.md) |
-| The canonical philosophy and invariants | [`../ARCHITECTURE.md`](../ARCHITECTURE.md) |
-| The operational rules for implementation work | [`../AGENTS.md`](../AGENTS.md) |
-| The honest implementation snapshot | [`where-we-are.md`](./where-we-are.md) |
-| The proposal tree and proposal statuses | [`design/README.md`](./design/README.md) |
+| Build and run basics | [`../README.md`](../README.md) |
+| The current implementation snapshot | [`where-we-are.md`](./where-we-are.md) |
+| The current runtime / repo structure | [`c4.md`](./c4.md) |
+| The logic / proof-format / translation landscape | [`institution-map.md`](./institution-map.md) |
+| The target philosophy and invariants | [`../ARCHITECTURE.md`](../ARCHITECTURE.md) |
+| Trusted-core implementation rules | [`../AGENTS.md`](../AGENTS.md) |
+| Design proposals and historical planning docs | [`design/README.md`](./design/README.md) |
 
-## Reading order
+## Reading Order
 
-For most contributors, the shortest useful path is:
+For most contributors:
 
-1. [`../README.md`](../README.md) for build/run basics.
-2. [`c4.md`](./c4.md) for the current architecture map.
-3. [`institution-map.md`](./institution-map.md) for the current logic/translation landscape.
-4. [`where-we-are.md`](./where-we-are.md) for what is shipping vs in flight.
-5. [`VISION.md`](./VISION.md) and [`../ARCHITECTURE.md`](../ARCHITECTURE.md) for the target shape.
+1. [`../README.md`](../README.md)
+2. [`where-we-are.md`](./where-we-are.md)
+3. [`c4.md`](./c4.md)
+4. [`institution-map.md`](./institution-map.md) if your work touches proofs,
+   importers, or logic translation
+5. [`../ARCHITECTURE.md`](../ARCHITECTURE.md) and [`../AGENTS.md`](../AGENTS.md)
+   if your work touches the trusted core or long-term architecture
 
-If you are changing trusted-core or storage semantics, read
-[`../AGENTS.md`](../AGENTS.md) in full before touching code.
+## Status Labels
 
-## Canonical vs provisional
+Use these labels consistently when updating docs:
 
-Use this distinction consistently:
+- `Current implementation`: intended to match the checked-in code
+- `Target architecture`: the direction the repo is trying to move toward
+- `Proposal`: a candidate design, not an adopted fact
+- `Historical`: useful context, but not a statement about the current tree
 
-- **Canonical / normative**:
-  [`../ARCHITECTURE.md`](../ARCHITECTURE.md),
-  [`../AGENTS.md`](../AGENTS.md)
-- **Current-state / descriptive**:
-  [`c4.md`](./c4.md),
-  [`institution-map.md`](./institution-map.md),
-  [`where-we-are.md`](./where-we-are.md),
-  [`prover-architecture.md`](./prover-architecture.md)
-- **Proposal / not yet committed**:
-  [`design/README.md`](./design/README.md) and everything under
-  [`design/proposals/`](./design/proposals/)
-- **Historical / partially superseded**:
-  [`refactor-plan.md`](./refactor-plan.md),
-  [`prover-mvp-plan.md`](./prover-mvp-plan.md),
-  [`../MVP_DESIGN.md`](../MVP_DESIGN.md),
-  [`../DESIGN.md`](../DESIGN.md)
+## Current Implementation Docs
 
-## What `c4.md` is for
+- [`where-we-are.md`](./where-we-are.md) — code-first snapshot of the workspace
+- [`c4.md`](./c4.md) — surfaces, runtime containers, and component groupings
+- [`institution-map.md`](./institution-map.md) — logic/integration map
+- [`prover-architecture.md`](./prover-architecture.md) — legacy
+  `covalence-kernel` implementation notes
+- [`prover-primops.md`](./prover-primops.md) and
+  [`prover-sexpr.md`](./prover-sexpr.md) — legacy kernel internals and syntax
 
-[`c4.md`](./c4.md) is the consolidation layer this tree was missing:
+## Target Architecture Docs
 
-- It gives a **Level 1 system context** for who uses Covalence.
-- It gives a **Level 2 container view** for the runnable surfaces.
-- It gives a **Level 3 component view** for how the repo is grouped today.
+- [`../ARCHITECTURE.md`](../ARCHITECTURE.md)
+- [`../AGENTS.md`](../AGENTS.md)
+- [`VISION.md`](./VISION.md)
 
-It is intentionally about the **current repo and runtime surfaces**, not a claim
-that every proposal in `docs/design/` has been adopted.
+These explain where the project is trying to go. They are not a literal map of
+today's runtime surfaces.
+
+## Proposals And History
+
+- [`design/README.md`](./design/README.md) — proposal index
+- [`refactor-plan.md`](./refactor-plan.md) — historical kernel refactor plan
+- [`prover-mvp-plan.md`](./prover-mvp-plan.md) — historical restart sketch
+- [`../MVP_DESIGN.md`](../MVP_DESIGN.md), [`../DESIGN.md`](../DESIGN.md) —
+  older design snapshots
+
+## One Important Rule
+
+If a document claims to describe the current codebase, verify it against files
+under `crates/`, `apps/`, `packages/`, and `extensions/`. If it claims to
+describe the architecture we want, link it to `ARCHITECTURE.md` or the relevant
+proposal and label it accordingly.

--- a/docs/c4.md
+++ b/docs/c4.md
@@ -1,32 +1,32 @@
 # C4 Architecture Map
 
-This document consolidates the repo into one architecture view.
+This is the current repo-and-runtime map for Covalence. It describes the code
+that exists today, not the whole target architecture described in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md).
 
-It is a map of the **current codebase and runtime surfaces**. It does **not**
-ratify every proposal in [`design/`](./design/) and it does **not** replace the
-canonical philosophy in [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+Use it with:
 
-Use it alongside:
-
-- [`where-we-are.md`](./where-we-are.md) for implementation status
-- [`VISION.md`](./VISION.md) for the short conceptual overview
-- [`../ARCHITECTURE.md`](../ARCHITECTURE.md) for the target architecture
+- [`where-we-are.md`](./where-we-are.md) for a narrative snapshot
+- [`institution-map.md`](./institution-map.md) for the logic/integration view
+- [`design/README.md`](./design/README.md) for proposals
 
 ## Level 1: System Context
 
 ```mermaid
 flowchart TB
-    contributor["Contributor<br/>builds, tests, extends the repo"]
-    browser_user["Browser user<br/>uses the web UI"]
-    editor_user["VS Code user<br/>edits .cov/.smt/.wat files"]
-    library_user["Library consumer<br/>Rust, Python, and TypeScript callers"]
-    external["External artifacts and runtimes<br/>SQLite, blob stores, WASM toolchain, proof/data formats"]
+    contributor["Contributor"]
+    cli_user["CLI user"]
+    browser_user["Browser user"]
+    editor_user["VS Code user"]
+    library_user["Python / TS / Rust consumer"]
+    external["External systems and formats<br/>SQLite, git remotes, WASM tooling,<br/>proof artifacts, local files"]
 
     subgraph cov["Covalence"]
-        system["Experimental theorem prover + VCS<br/>content-addressed substrate<br/>multiple kernel/prover tracks<br/>CLI, server, editor, and web surfaces"]
+        system["Monorepo with store/object substrate,<br/>multiple prover lines, CLI/server/editor/browser surfaces"]
     end
 
     contributor --> system
+    cli_user --> system
     browser_user --> system
     editor_user --> system
     library_user --> system
@@ -35,126 +35,126 @@ flowchart TB
 
 ### Interpretation
 
-- Covalence is not a single deployable binary. It is a repo with several user
-  surfaces over a shared Rust workspace.
-- The same codebase serves different modes: direct CLI use, HTTP/web use, editor
-  use, and library embedding.
-- External runtimes and formats are first-class at the edges, which matches the
-  repo's emphasis on wrappers, oracles, and re-checkable integration.
+- Covalence is a multi-surface monorepo, not a single executable.
+- The same repository serves storage work, theorem tooling, language tooling,
+  and browser/editor integrations.
+- External artifacts are part of the normal operating model: git data, WASM,
+  proof formats, SQLite-backed persistence, and content-addressed blobs.
 
 ## Level 2: Container View
 
 ```mermaid
 flowchart TB
-    contributor["Contributor"]
+    cli_user["CLI user"]
     browser_user["Browser user"]
     editor_user["VS Code user"]
-    py_user["Python / TS consumer"]
+    py_ts_user["Python / TS user"]
 
-    subgraph cov["Covalence repo"]
-        cli["CLI + REPL<br/>crates/covalence<br/>crates/covalence-repl"]
-
-        serve["HTTP server<br/>crates/covalence-serve"]
-
-        web["Web app<br/>apps/covalence-web"]
-
-        vscode["VS Code extension<br/>extensions/covalence-vscode"]
-
-        py["Python bindings<br/>crates/covalence-python"]
-
-        tspkgs["TS packages<br/>packages/covalence-client<br/>packages/covalence-ui<br/>packages/covalence-wasm-js"]
-
-        core["Rust workspace core<br/>kernel, substrate, wrappers,<br/>logic/proof, and protocol crates"]
+    subgraph surfaces["Covalence surfaces"]
+        cli["`cov` CLI<br/>repl / serve / cog / hol / lsp"]
+        server["`covalence-serve`<br/>HTTP + WebSocket API"]
+        web["`apps/covalence-web`<br/>SvelteKit SPA"]
+        vscode["`extensions/covalence-vscode`<br/>native or WASM LSP"]
+        libs["Python + TS packages"]
     end
 
-    sqlite["SQLite / local storage"]
-    wasm["WASM tooling and runtimes"]
+    subgraph runtime["Shared runtime and libraries"]
+        shell["`covalence-shell`<br/>backend traits + store-first Kernel + Prover trait"]
+        substrate["Store / object / hash / WASM crates"]
+        logic["Kernel / Pure / HOL / proof bridges"]
+        proto["Discovery and config"]
+    end
 
-    contributor --> cli
-    contributor --> serve
-    contributor --> vscode
-
+    cli_user --> cli
     browser_user --> web
-    web --> tspkgs
-    web --> serve
-
     editor_user --> vscode
-    vscode --> core
+    py_ts_user --> libs
 
-    py_user --> py
-    py_user --> tspkgs
+    cli --> server
+    cli --> shell
+    server --> shell
+    server --> proto
+    web --> server
+    web --> libs
+    vscode --> proto
+    vscode --> shell
+    libs --> server
+    libs --> shell
 
-    cli --> core
-    serve --> core
-    py --> core
-
-    core <--> sqlite
-    core <--> wasm
+    shell --> substrate
+    shell --> logic
 ```
 
 ### Notes
 
-- `covalence-serve` is the main network-facing container; the web app sits on top
-  of it rather than replacing it.
-- The VS Code extension is a separate user surface with its own transport/runtime
-  choices, not just a skin over the web app.
-- The repo also exposes library surfaces directly through Python and TypeScript
-  packages.
+- `covalence-serve` is the main network container.
+- The browser UI is a client of the server, not a replacement for it.
+- The VS Code extension is its own surface with both native and browser-hosted
+  modes.
+- `covalence-shell` is the runtime seam that matters most today.
+- The removal people are most likely to remember here is the old `HolPrim`
+  adapter path, not the `covalence-pure` crate itself.
 
 ## Level 3: Codebase Component View
 
 ```mermaid
 flowchart LR
     subgraph surfaces["User-facing surfaces"]
-        s1["covalence<br/>CLI entrypoint"]
-        s2["covalence-repl<br/>interactive shell"]
-        s3["covalence-serve<br/>HTTP / WebSocket API"]
-        s4["covalence-lsp<br/>language server"]
-        s5["covalence-python<br/>Python API"]
-        s6["covalence-web<br/>Svelte UI"]
-        s7["covalence-vscode<br/>editor integration"]
+        s1["`covalence` CLI"]
+        s2["`covalence-repl`"]
+        s3["`covalence-serve`"]
+        s4["`covalence-lsp`"]
+        s5["`covalence-python`"]
+        s6["`apps/covalence-web`"]
+        s7["`extensions/covalence-vscode`"]
     end
 
-    subgraph protocol["Transport and shared client layer"]
-        p1["covalence-client<br/>remote backend client"]
-        p2["covalence-proto<br/>discovery and config"]
-        p3["packages/covalence-client<br/>TS client"]
-        p4["packages/covalence-ui<br/>Svelte components"]
+    subgraph client["Client and discovery layer"]
+        c1["`covalence-client`"]
+        c2["`covalence-proto`"]
+        c3["`packages/covalence-client`"]
+        c4["`packages/covalence-ui`"]
+        c5["`packages/covalence-wasm-js`"]
     end
 
-    subgraph logic["Logic and prover experiments"]
-        l1["covalence-kernel<br/>current legacy shell target"]
-        l2["covalence-hol<br/>separate HOL kernel"]
-        l3["covalence-pure<br/>covalence-pure-shell"]
-        l4["covalence-opentheory<br/>covalence-metamath<br/>covalence-lean<br/>covalence-egglog"]
+    subgraph shell["Backend seam"]
+        h1["`covalence-shell`<br/>Sync/Async backend traits<br/>store-first Kernel<br/>Prover trait"]
     end
 
-    subgraph substrate["Substrate and wrapper crates"]
-        t1["Storage and identity<br/>covalence-store<br/>covalence-object<br/>covalence-git<br/>covalence-sqlite<br/>covalence-kv<br/>covalence-fuse<br/>covalence-wasm-store"]
-        t2["Execution and formats<br/>covalence-wasm<br/>covalence-wasm-spec<br/>covalence-wasm-build-guest<br/>covalence-spectec<br/>covalence-graph"]
-        t3["Foundational wrappers<br/>covalence-hash<br/>covalence-types<br/>covalence-parse<br/>covalence-sexp<br/>covalence-rand<br/>covalence-sig<br/>covalence-json"]
-        t4["Reasoning/data helpers<br/>covalence-sat<br/>covalence-smt<br/>covalence-alethe<br/>covalence-arrow<br/>covalence-parquet<br/>covalence-grammar<br/>covalence-forsp<br/>covalence-llm"]
+    subgraph logic["Logic and proof families"]
+        l1["`covalence-kernel`"]
+        l2["`covalence-pure` + `covalence-pure-shell`"]
+        l3["`covalence-hol`"]
+        l4["OpenTheory / SMT / SAT / egglog / Lean / Metamath bridges"]
+    end
+
+    subgraph substrate["Substrate and data crates"]
+        t1["Store/object/hash/git/kv/fuse/wasm-store"]
+        t2["WASM/spec/graph/SpecTec"]
+        t3["Shared parsers and types"]
+        t4["Arrow / Parquet / Forsp / JSON / grammar / LLM helpers"]
     end
 
     s1 --> s2
     s1 --> s3
-    s2 --> l1
-    s3 --> l1
-    s4 --> p1
-    s5 --> l1
-    s6 --> p3
+    s1 --> s4
+    s1 --> h1
+    s5 --> h1
+    s6 --> c3
+    s6 --> c4
     s7 --> s4
 
-    p1 --> l1
-    p2 --> s3
-    p3 --> s3
-    p4 --> s6
+    c1 --> h1
+    c2 --> s3
+    c3 --> s3
+    c5 --> t2
 
-    l1 --> t1
-    l1 --> t2
+    h1 --> l1
+    h1 --> t1
+    l4 --> h1
+    l4 --> l3
     l2 --> t3
     l3 --> t3
-    l4 --> l2
 
     t1 --> t3
     t2 --> t3
@@ -163,29 +163,30 @@ flowchart LR
 
 ### Why this grouping
 
-- The repo is too large for a crate-per-box diagram to stay readable.
-- The meaningful split is between:
-  user-facing surfaces, transport/protocol adapters, prover/kernel lines, and
-  substrate/wrapper crates.
-- The current implementation still has **multiple prover lines in parallel**,
-  which is why the logic cluster is shown as a family instead of a single core.
+- The workspace is too large for a crate-per-node diagram to stay readable.
+- The operationally meaningful splits are:
+  surfaces, client/discovery code, shell/runtime seams, logic/proof families,
+  and the substrate crates.
+- The codebase genuinely has multiple prover/kernel families active at once, so
+  the logic area is shown as a cluster rather than a single canonical core.
 
 ## Directory Map
 
-| Area | What it mainly contains |
+| Area | What it contains now |
 |---|---|
-| `crates/` | Rust workspace: user surfaces, substrate crates, kernels, experiments, wrappers |
-| `apps/covalence-web/` | SvelteKit SPA for browser use |
-| `packages/` | Shared TypeScript packages used by the web app and browser/WASM integrations |
-| `extensions/covalence-vscode/` | VS Code extension for native and browser-hosted editor scenarios |
-| `docs/` | Current-state docs, proposal docs, and planning/history |
-| `assets/` | Test assets and imported/spec-related source material |
-| `tests/`, `test-workbench/` | Integration and experimentation scaffolding |
+| `crates/` | Rust workspace members for surfaces, substrate crates, kernels, proof bridges, and wrappers |
+| `apps/covalence-web/` | SvelteKit SPA using the TS client and UI packages |
+| `packages/` | TypeScript client, reusable UI, and JS WASM runtime package |
+| `extensions/covalence-vscode/` | VS Code extension with native and WASM execution paths |
+| `docs/` | Current-state docs, target-architecture docs, proposals, and history |
+| `assets/` | Imported materials and shared fixtures |
+| `tests/`, `test-workbench/` | Integration and experimental scaffolding |
 
-## Reading the repo after this page
+## What This Map Does Not Claim
 
-If you want the implementation snapshot after this map, continue with
-[`where-we-are.md`](./where-we-are.md).
+- It does not claim the long-term architecture is settled.
+- It does not imply `covalence-kernel`, `covalence-pure`, and `covalence-hol`
+  have already been unified.
+- It does not ratify any proposal under [`design/`](./design/).
 
-If you want the intended end-state after this map, continue with
-[`VISION.md`](./VISION.md) and [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+It is only a map of the current implementation landscape.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,99 +1,49 @@
-# Design (planning-stage)
+# Design Proposals
 
-This directory holds **design discussions and proposals** for Covalence.
-Nothing here is a committed architecture; everything is a draft awaiting
-review, revision, and eventual implementation (or rejection).
+This directory holds design work that is intentionally separate from the
+current implementation snapshot.
 
-For an honest snapshot of what is *actually built* (and what's stale or
-superseded), see [`../where-we-are.md`](../where-we-are.md).
+Nothing here should be read as “this is how the repo works today” unless some
+other current-state document explicitly says that a proposal has been adopted.
 
-For the big-picture vision the proposals are working toward, see
-[`../../ARCHITECTURE.md`](../../ARCHITECTURE.md) (v2) and
-[`../../AGENTS.md`](../../AGENTS.md).
+For the code as it exists now, read [`../where-we-are.md`](../where-we-are.md).
+For the architectural north star, read [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md)
+and [`../../AGENTS.md`](../../AGENTS.md).
 
-For a current-state classification of the repo's multiple logic families,
-proof formats, and bridges, see [`../institution-map.md`](../institution-map.md).
+## What Lives Here
 
----
+- proposal sets for possible future architecture,
+- design sketches around specific subsystems,
+- planning and migration notes that are useful context but not current-state
+  truth.
 
-## How this directory is organized
+## Active Proposal Sets
 
-```
-docs/design/
-  README.md             — this file (design directory index)
-  proposals/            — concrete proposals, each in its own subdir
-    <proposal-name>/
-      README.md         — proposal's own index
-      <doc>.md          — the proposal's design docs
-```
+| Proposal | Status | Summary |
+|---|---|---|
+| [`proposals/layered-framework/`](./proposals/layered-framework/) | proposed | Three-layer kernel direction: Framework / HOL / Morphism, with more machinery pushed out of the TCB. |
+| [`proposals/stacked-pure-hol/`](./proposals/stacked-pure-hol/) | proposed | Minimal Pure/LF + HOL stack in the Isabelle/Pure tradition. |
+| [`proposals/shared-backbone/`](./proposals/shared-backbone/) | proposed | Migration path centered on a shared content-addressed substrate for prover and VCS work. |
+| [`proposals/egglog-integration/`](./proposals/egglog-integration/) | proposed | Catalogue-style egglog integration for selected theories and decision questions. |
+| [`proposals/wasm-runtime/`](./proposals/wasm-runtime/) | proposed | WIT-shaped runtime abstraction for `covalence-wasm` across native and browser hosts. |
+| [`proposals/wasm-store-composition/`](./proposals/wasm-store-composition/) | sketch | WASM components as composable content-addressed stores. |
 
-A "proposal" here is a coherent set of design choices that hang
-together. Two different proposals in this directory may make
-*incompatible* claims — that's expected; they're alternatives or
-revisions. The status of each proposal (proposed, under-review,
-accepted, rejected, superseded) is recorded in the proposal's own
-`README.md`.
+## How To Use This Directory
 
----
+- Treat proposal docs as candidate designs, not as implementation references.
+- When a proposal is adopted, the current-state docs and root architecture docs
+  should be updated to say so explicitly.
+- If a proposal is abandoned or superseded, keep it for history but label it
+  clearly.
 
-## Active proposals
+## What Does Not Belong Here
 
-| Proposal                                                                                              | Status   | Summary                                                                                                                                  |
-|-------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------|
-| [`proposals/layered-framework/`](./proposals/layered-framework/)                                       | proposed | Carve the kernel into three layers (Framework / HOL / Morphism), with stores and authorities as the framework's only trust primitives. Hash functions, signatures, executors all become oracles outside the trust boundary. |
-| [`proposals/stacked-pure-hol/`](./proposals/stacked-pure-hol/)                                         | proposed | Minimal **Pure/LF + HOL** kernel sketch in the Isabelle/Pure tradition: a tiny logical framework at the bottom, HOL as the default object logic above it, and shell/oracle machinery outside the TCB. This is the clearest "Larry Paulson homage" document in the tree and now aligns with the institution-theoretic framing in [`../institution-map.md`](../institution-map.md). |
-| [`proposals/shared-backbone/`](./proposals/shared-backbone/)                                           | proposed | The *path* to the vision. Substrate-first with two parallel streams (prover + VCS) sharing a content-addressed backbone; oracle-everything stratification (Stores leave the framework; verifiable reads become oracle observations); `attest`/`decide` reframed as the first concrete oracle. Sibling to `layered-framework/`, not an alternative. |
-| [`proposals/egglog-integration/`](./proposals/egglog-integration/)                                     | proposed | Curate a **patchwork of small (theory, decision question) entries** where egglog is the right engine — EUF, pure equational theories, arrays, lists, AC word problems, Datalog reachability, lattice analyses — each shipping into the kernel as its own family of `EThm`s. Two engineering layers under the catalogue (oracle replay vs. native runner) and a long-term meta-provability mode. |
-| [`proposals/wasm-runtime/`](./proposals/wasm-runtime/)                                                 | proposed | Abstract `covalence-wasm`'s engine surface behind a sync-first `cov:wasm/*@0.1.0` WIT API (runtime / inspect / build) so the same code can target wasmtime, a browser JS host, or guest components; layer **process** (shared-fate graph of components) and **container** (tree of processes with restart policies) on top; end goal is a browser-resident covalence kernel powering a fully static `covalence-ui`, with federation as a longer-term follow-up. |
-| [`proposals/wasm-store-composition/`](./proposals/wasm-store-composition/)                             | sketch   | Stores as content-addressed WASM components carrying their own JSON manifest in a custom section. Tree-shaped composition via a resource-typed `cov:store/api` and a `build(list<store>) -> store` factory. Roadmap: resource WIT → hash-keyed `StoreRef` → `StoreRegistry` that walks the graph. Naturally rides on top of `wasm-runtime`'s `cov:wasm/*@0.1.0` abstraction (composer-side host calls become `cov:wasm/runtime` API calls, browser/native parity for free). |
+- Literal descriptions of the current runtime surfaces
+- Verified build/test instructions
+- File-by-file workspace maps
 
----
+Those belong in:
 
-## Accepted / rejected proposals
-
-(none yet)
-
----
-
-## How proposals become decisions
-
-The intent is that a proposal here is *one of several possible* design
-directions. Adoption requires:
-
-1. A round of discussion and revision in the proposal's docs.
-2. Explicit acknowledgment that this is the direction we're taking
-   (e.g., a note in [`../where-we-are.md`](../where-we-are.md) marking
-   the proposal as "accepted" and updating the `ARCHITECTURE.md` /
-   `AGENTS.md` to reflect the new direction).
-3. A migration / implementation plan with phased steps that don't
-   require committing to the whole proposal up front.
-
-Until those steps are done, a proposal in this directory is just a
-record of a planning conversation — useful for cross-referencing, but
-not load-bearing for the codebase.
-
-One extra distinction now matters during the refactor: some proposals
-primarily define a **trusted logical core** (`layered-framework`,
-`stacked-pure-hol`), while others define **translation, tooling, or
-deployment structure around that core** (`shared-backbone`,
-`egglog-integration`, `wasm-runtime`, `wasm-store-composition`). That
-split roughly matches the institution-theoretic distinction between
-institutions and the external artifacts/translations that relate them.
-
----
-
-## What's NOT here
-
-- **Implementation plans** for the *current* kernel. Those live in
-  [`../refactor-plan.md`](../refactor-plan.md) and
-  [`../prover-mvp-plan.md`](../prover-mvp-plan.md).
-- **Current kernel internals.** Documented in
-  [`../prover-architecture.md`](../prover-architecture.md) and
-  [`../prover-primops.md`](../prover-primops.md).
-- **The S-expression syntax.** Documented in
-  [`../prover-sexpr.md`](../prover-sexpr.md).
-- **The Prop-egraph (Phase P) design.** Documented in
-  [`../prop-egraph-design.md`](../prop-egraph-design.md).
-
-These are descriptions of what exists or what's in-flight, not
-proposals for new directions.
+- [`../where-we-are.md`](../where-we-are.md)
+- [`../c4.md`](../c4.md)
+- [`../../README.md`](../../README.md)

--- a/docs/where-we-are.md
+++ b/docs/where-we-are.md
@@ -1,339 +1,246 @@
-# Where We Are (planning-stage)
+# Where We Are
 
-Honest snapshot of the Covalence tree as of the `planning-stage` branch.
-Captures what's shipping, what's in flight, what's stale, and what's planned
-but not yet started. Read this before the design docs in
-[`docs/design/`](./design/).
+This is the current implementation snapshot for the repository as it exists in
+the tree now. It is intentionally code-first: it describes what is present,
+what is wired together, and where the repo still has parallel tracks or obvious
+transition seams.
 
-> **Note on status.** Everything in [`docs/design/proposals/`](./design/proposals/)
-> is **proposed**, not committed. Those docs describe a possible
-> direction (the layered-framework proposal), not a decided
-> architecture. The list of in-flight code and superseded docs below
-> *is* current; the "new direction" referenced is one proposal we're
-> currently exploring, not a settled plan.
+It does not try to settle the long-term architecture. For that, read
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md) and
+[`design/README.md`](./design/README.md).
 
 ## TL;DR
 
-We've successfully built the **substrate** (content-addressed store,
-BLAKE3 wrappers, WASM engine, signature scheme, parsers, S-expressions).
-We have **three parallel kernels** in various stages of development, none
-of which match the target architecture. Application crates (REPL, server,
-client, LSP, VSCode extension, web app) work against the *oldest* kernel
-design. We are mid-replanning — these docs are the planning artifact.
+The repo is no longer just a kernel experiment plus a few shells around it.
+Today it is a broad monorepo with:
 
-The currently-favored direction is the **layered-framework proposal**
-([`docs/design/proposals/layered-framework/`](./design/proposals/layered-framework/)):
-a tiny
-[Framework](./design/proposals/layered-framework/02-framework.md)
-(Pure-style LF) at the bottom, a
-[HOL layer](./design/proposals/layered-framework/) as an object theory
-over it, and a
-[Morphism layer](./design/proposals/layered-framework/) above that.
-Hashing, signatures, executors, and the namespace machinery are all
-**outside the trust boundary** as oracles or untrusted layers. This is
-a *proposal*, not a decided architecture — alternatives are welcome.
+- a working CLI, HTTP server, REPL, LSP, browser UI, VS Code extension,
+  Python bindings, and TypeScript clients,
+- a content-addressed storage stack (`covalence-store`, `covalence-object`,
+  `covalence-git`, `covalence-kv`, `covalence-fuse`, `covalence-wasm-store`),
+- multiple coexisting logic / prover lines (`covalence-kernel`,
+  `covalence-pure`, `covalence-hol`),
+- bridge and certificate crates for OpenTheory, Alethe/SMT, SAT, egglog,
+  Metamath, Lean export data, and SpecTec/WASM assets,
+- a thin `covalence-shell::Kernel` used by the REPL and server as a store-first
+  backend, plus a separate `Prover` trait used by theorem-oriented frontends.
 
-Institution-theoretically, this is a shift toward a **Paulson-style
-split**: LF/Pure as the meta-institution, HOL as the default object
-institution, and everything else treated as theories, proof languages,
-or translations around that core. The intended TCB is therefore not
-"the current kernel plus helpers" but **LF + HOL**, with morphism
-machinery, package transport, stores, executors, hashing, and
-certificate tooling all outside that trusted center.
+The important current fact is coexistence: the repo already contains more than
+one “core”, and different surfaces target different layers of that stack.
 
-The **[shared-backbone proposal](./design/proposals/shared-backbone/)**
-is a sibling: it adopts the layered-framework kernel shape and adds
-*the path* — substrate-first with the prover and VCS developed in
-parallel over a content-addressed shared backbone, an
-oracle-everything stratification (Stores leave the framework;
-verifiable reads become oracle observations rather than TCB
-primitives), and `attest`/`decide` reframed as the first concrete
-oracle (not legacy). The kill list, the four phases, and the
-supersession of [`refactor-plan.md`](./refactor-plan.md) Phase A–H +
-Phase P are documented there. Read together with `layered-framework/`.
+One easy point of confusion: `covalence-pure` was not purged. The thing that
+was removed was the legacy `HolPrim` adapter path in `covalence-shell`. The
+Pure crates are still present and active.
 
----
+## User-Facing Surfaces
 
-## 1. The substrate (shipping, considered correct shape)
+### CLI
 
-These wrapper crates have stable APIs and are used throughout. The
-[wrapper-crate discipline](../CLAUDE.md#wrapper-crates) is well-
-established and should continue through the redesign.
+The `cov` binary in [`../crates/covalence`](../crates/covalence) currently
+exposes:
 
-| Crate                 | Wraps                                  | Status |
-|-----------------------|----------------------------------------|--------|
-| `covalence-store`     | content-addressed blob storage         | shipping |
-| `covalence-hash`      | BLAKE3 (default+keyed+derive), SHA-256, Git hashes | shipping |
-| `covalence-wasm`      | `wat`/`wasmparser`/`wasmprinter`/`wasm-encoder`, optional `wasmtime` | shipping |
-| `covalence-sqlite`    | `rusqlite` + recommended pragmas       | shipping |
-| `covalence-git`       | git-compatible objects + LFS           | shipping |
-| `covalence-rand`      | `rand` + RNG abstractions              | shipping |
-| `covalence-sig`       | Ed25519 (via `ed25519-dalek`)          | shipping |
-| `covalence-parse`     | `winnow` + LEB128                      | shipping |
-| `covalence-sexp`      | S-expression parser with dialects      | shipping |
-| `covalence-types`     | `Decision`, `Bits`, `Nat`/`Int`        | shipping |
-| `covalence-sat`       | SAT formulas, DIMACS, DRAT             | shipping |
-| `covalence-smt`       | SMT-LIB2, theories, Alethe             | shipping |
-| `covalence-object`    | `Dir`/`Table` serialization            | shipping |
+- `cov repl`
+- `cov serve`
+- `cov cog`
+- `cov hol check`
+- `cov lsp`
 
----
+Feature-gating still exists, but the default native build enables the main
+surfaces. `cov serve` and `cov repl` are native-only; the binary prints a clear
+error on WASM targets.
 
-## 2. Three kernels coexist
+### HTTP Server
 
-One useful way to read this section during the refactor: these are not
-just "three kernels," they are three different answers to
-"what institution or meta-institution is primary here?"
+[`../crates/covalence-serve`](../crates/covalence-serve) is an axum server with:
 
-### 2.1 `covalence-kernel` (~4.9k LoC)
+- `/api/info` and `/api/health`
+- `/api/repl` WebSocket REPL
+- blob endpoints under `/api/blobs`
+- tagged-object endpoints under `/api/tagged`
+- git/object-store endpoints under `/api/objects`
+- `/api/eval` for stateless S-expression evaluation
 
-The current focus of the Phase A–H refactor described in
-[`docs/refactor-plan.md`](./refactor-plan.md). Arena + UF + Prop + Thm +
-Context + concept system. Recently shipped:
+The server listens on TCP and a Unix domain socket, and registers itself with
+[`../crates/covalence-proto`](../crates/covalence-proto)'s discovery layer.
 
-- **Phase F1** — `VarId`/`TyVarId` newtypes
-- **Phase H** — `Arena::hash()` content addressing *(problematic — see
-  [§5 Open issues](#5-open-issues-with-the-current-code))*
-- **Phase G3** — `declare_type_operator` with tyvar order validation
-- **Phase P** (partial) — parallel `EProp`/`EThm` egraph types alongside
-  legacy `Prop`/`Thm`
+### Browser UI
 
-| File          | LoC  |
-|---------------|------|
-| `arena.rs`    | 1933 |
-| `prop.rs`     |  781 |
-| `ty.rs`       |  388 |
-| `hash.rs`     |  365 |
-| `term.rs`     |  247 |
-| `kernel.rs`   |  235 |
-| `uf.rs`       |  176 |
-| `primop.rs`   |  167 |
-| `reduce.rs`   |  167 |
-| `eprop.rs`    |  140 |
-| `id.rs`       |  112 |
-| `subst.rs`    |   60 |
-| `egraph.rs`   |   44 |
-| `lib.rs`      |   37 |
+[`../apps/covalence-web`](../apps/covalence-web) is a SvelteKit SPA that
+currently includes:
 
-### 2.2 `covalence-hol` (~2.1k LoC)
+- a REPL page backed by the WebSocket API,
+- an object viewer for blobs and trees,
+- a `cov:graph` viewer page.
 
-A separate HOL-Light-shaped kernel with its own arena, term/type system,
-and LCF-style inference rules. **Explicitly "left untouched" per the
-original MVP plan.** Used as the proof target of `covalence-opentheory`.
+It consumes the TypeScript packages in `packages/` rather than talking to the
+Rust server directly.
 
-In the newer vocabulary from [`institution-map.md`](./institution-map.md),
-this is the clearest current **object-institution** implementation in
-the tree. It is also the main reference point for the proposed
-CovalenceHOL layer.
+### VS Code Extension
 
-| File         | LoC  |
-|--------------|------|
-| `light.rs`   |  958 |
-| `arena.rs`   |  630 |
-| `null.rs`    |  349 |
-| `traits.rs`  |  231 |
-| `types.rs`   |  129 |
-| `lib.rs`     |   14 |
+[`../extensions/covalence-vscode`](../extensions/covalence-vscode) provides:
 
-### 2.3 `covalence-opentheory` (~2k LoC)
+- language support for `.smt`, `.smt2`, `.alethe`, `.cov`, and `.wat`,
+- native-binary LSP when a `cov` path is configured,
+- browser/WASM fallback via `@vscode/wasm-wasi` and
+  `@vscode/wasm-wasi-lsp`.
 
-OpenTheory article reader → drives `covalence-hol`. Substantive logic,
-not just plumbing.
+### Python And TypeScript Libraries
 
-Institutionally this is best read as a **theory/package transport**
-layer for HOL-family content, not as a separate logic.
+- [`../crates/covalence-python`](../crates/covalence-python) exposes Python
+  bindings for storage, graphs, signing, server/client helpers, WASM, and the
+  Pure kernel family.
+- [`../packages/covalence-client`](../packages/covalence-client) is a TS client
+  for `cov serve`.
+- [`../packages/covalence-ui`](../packages/covalence-ui) contains reusable
+  Svelte viewers and the `cov:graph` UI.
+- [`../packages/covalence-wasm-js`](../packages/covalence-wasm-js) is a JS host
+  runtime for the `cov:wasm/runtime@0.1.0` direction, using native
+  `WebAssembly.*` for modules and `jco` for components.
 
-| File           | LoC  |
-|----------------|------|
-| `interp.rs`    |  802 |
-| `resolve.rs`   |  549 |
-| `theory.rs`    |  313 |
-| `fetch.rs`     |  179 |
-| `name.rs`      |  101 |
-| `reader.rs`    |   70 |
-| `machine.rs`   |   70 |
-| `object.rs`    |   69 |
+## The Current Runtime Split
 
----
+Three layers matter operationally today.
 
-## 3. Application shells (work against the *oldest* design)
+### 1. Store And Object Substrate
 
-These all bind to `covalence-kernel`'s legacy `decide` / `attest()` model
-(WASM-component-as-proposition; see superseded
-[`MVP_DESIGN.md`](../MVP_DESIGN.md)):
+These crates are concrete and broadly reusable now:
 
-| Crate / app                     | Purpose                                  |
-|---------------------------------|------------------------------------------|
-| `covalence-repl`                | S-expression REPL via `Session`          |
-| `covalence-serve`               | REST + WebSocket server (axum 0.8)       |
-| `covalence-client`              | sync/async HTTP client for remote kernel |
-| `covalence-lsp`                 | LSP for `.smt`/`.smt2`/`.alethe`/`.cov`/`.wat` |
-| `covalence` (CLI binary `cov`)  | clap + color-eyre                        |
-| `covalence-python`              | PyO3 bindings                            |
-| `extensions/covalence-vscode`   | VS Code extension                        |
-| `apps/covalence-web`            | SvelteKit web app                        |
+| Area | Crates | What they do now |
+|---|---|---|
+| Hashing and identities | `covalence-hash`, `covalence-types`, `covalence-rand`, `covalence-sig` | Content hashes, shared numeric/bit types, RNG, signatures |
+| Parsing and syntax | `covalence-parse`, `covalence-sexp`, `covalence-json`, `covalence-grammar`, `covalence-forsp` | Parsers, S-expression dialects, Forsp evaluation |
+| Blob / object storage | `covalence-store`, `covalence-sqlite`, `covalence-object`, `covalence-kv`, `covalence-git`, `covalence-fuse`, `covalence-wasm-store` | Content stores, git-compatible objects, directories/tables, KV backends, Linux FUSE mounting, WASM-packaged store helpers |
+| WASM and format support | `covalence-wasm`, `covalence-wasm-spec`, `covalence-wasm-build-guest`, `covalence-graph`, `covalence-arrow`, `covalence-parquet`, `covalence-spectec` | WAT/WASM compile/parse/build, reference WASM components, graph bytes, Arrow/Parquet inspection, SpecTec ingestion |
 
-They work, but they reason against the *propositional WASM* model, not
-the HOL kernel. Any layered redesign needs to swap their bindings — the
-plan is to keep them stable against the legacy kernel until the new
-layered stack is implementable, then migrate.
+This is the most concrete and consistently implemented part of the repo.
 
----
+### 2. Shell / Service Layer
 
-## 4. Vision, supersession, and the new design
+[`../crates/covalence-shell`](../crates/covalence-shell) is now the main seam
+between storage-oriented surfaces and theorem-oriented surfaces.
 
-### Canonical vision
+It contains:
 
-- [`ARCHITECTURE.md`](../ARCHITECTURE.md) (v2) at the repo root — the
-  big picture: planes, mirrors, oracles, mount-as-implication, format
-  plane, base-shift functor.
-- [`AGENTS.md`](../AGENTS.md) — operational summary of `ARCHITECTURE.md`.
+- `SyncBackend` / `AsyncBackend`
+- a store-first in-memory `Kernel`
+- the `Prover` trait used by theorem/proof importers
 
-### Superseded (kept for history)
+That split is important:
 
-- [`MVP_DESIGN.md`](../MVP_DESIGN.md) — WASM-component-as-proposition
-  model. Predates the HOL vision.
-- [`DESIGN.md`](../DESIGN.md) — first sketch of the HOL kernel. Refined
-  into [`docs/prover-architecture.md`](./prover-architecture.md),
-  itself refined into the design docs in [`docs/design/`](./design/).
+- the `Kernel` in `covalence-shell` is currently a thin backend around a blob
+  store plus tree tracking,
+- the theorem-prover abstraction lives beside it, not inside it.
+- an older shell-side `HolPrim` adapter was removed, which is separate from
+  the continued existence of `covalence-pure` and `covalence-hol`.
 
-### In flight
+### 3. Logic / Prover Lines
 
-- [`docs/refactor-plan.md`](./refactor-plan.md) (Phases A–H) — kernel
-  cleanup. Continuing to land; strategic value uncertain given the
-  layered redesign.
-- [`docs/prover-architecture.md`](./prover-architecture.md) — current
-  kernel architecture; predates the framework concept and the
-  store-as-primitive insight.
-- [`docs/prover-mvp-plan.md`](./prover-mvp-plan.md) — earlier
-  "wipe-and-restart" plan; the Phase 0 reset never happened.
+The repo currently contains several parallel logic-related implementations:
 
-### The currently-favored direction (proposed, not committed)
+| Crate | Current role |
+|---|---|
+| `covalence-kernel` | Arena/egraph/UF theorem kernel and the main backend for the current `Prover` implementations |
+| `covalence-pure` | Small Pure-style logical framework with its own tests and shell crate |
+| `covalence-pure-shell` | Hashing / S-expression shell around `covalence-pure` |
+| `covalence-hol` | HOL Light-style kernel used directly by OpenTheory checking/import |
 
-The [layered-framework proposal](./design/proposals/layered-framework/)
-and the [stacked Pure + HOL MVP sketch](./design/proposals/stacked-pure-hol/README.md)
-now point in the same direction: shrink the trusted center to a
-**Pure/LF layer plus a HOL layer**, in deliberate homage to the
-Isabelle/Pure + object-logic split associated with Larry Paulson, while
-treating translations between logics as first-class structure rather
-than ambient coercions.
+This is not just “old versus new”. These lines are all live in code and have
+real consumers today.
 
-In institution-theoretic terms:
+If you were expecting `covalence-pure` to be gone, the likely source of that
+impression is the `covalence-shell` cleanup that removed the old `HolPrim`
+adapter once OpenTheory consumers moved to `PureHol` directly.
 
-1. **LF / Pure** is the candidate **meta-institution**.
-2. **HOL** is the default **object institution** hosted over it.
-3. **Morphism / institution-translation machinery** sits above that
-   trusted pair and mediates movement among theories, logics, proof
-   formats, and future semantics artifacts.
+## Proof, Import, And Solver Crates
 
-Concretely, the layered-framework sketch still describes three layers:
+These crates form the current “logic zoo” around the kernels:
 
-1. **CovalenceFramework** — Pure-style logical framework (LF). Would
-   be one half of the actual TCB /
-   [meta-trust set](./design/proposals/layered-framework/00-glossary.md#meta-trust-set).
-   ~700–800 LoC target. New crate. Described in
-   [`docs/design/proposals/layered-framework/02-framework.md`](./design/proposals/layered-framework/02-framework.md).
-2. **CovalenceHOL** — classical HOL as an object theory over the
-   framework. This is the other half of the shrunken TCB. Subset
-   typedef with the disjunct trick, the existentials, ε-choice,
-   primops. Doc pending.
-3. **CovalenceMorphism** — embeddings, equiconsistency, base-shift,
-   commutative-diagram API. Doc pending.
+| Family | Crates | Current role |
+|---|---|---|
+| HOL / package transport | `covalence-opentheory` | Read and interpret OpenTheory articles against `covalence-hol` |
+| SMT and proof ingest | `covalence-smt`, `covalence-alethe` | SMT-LIB terms/problems plus Alethe bridge/checking |
+| SAT and certificates | `covalence-sat` | DIMACS, DRAT, LRAT, solver traits, proof parsing |
+| Equality saturation | `covalence-egglog` | egglog AST/parse/lowering/bridge/proof ingestion |
+| Other proof ecosystems | `covalence-metamath`, `covalence-lean` | Metamath verification and Lean export ingestion |
+| Misc. theorem-adjacent | `covalence-llm` | OpenAI-backed WIT-facing LLM backend experiments |
 
-Around the framework, every hash function, every signature scheme,
-every executor would be an **oracle** outside the trust boundary.
+The stable story here is not “one proof pipeline”; it is “many bridges into
+shared backend traits and kernel-adjacent representations”.
 
-This is one **proposal**. It hasn't been formally adopted; alternative
-directions and revisions are welcome. The proposal lives at
-[`docs/design/proposals/layered-framework/`](./design/proposals/layered-framework/)
-with its own index.
+## What The Main Surfaces Actually Target
 
----
+Today the user-facing surfaces split into two broad camps.
 
-## 5. Open issues with the current code
+### Store-first surfaces
 
-These are concerns the **layered-framework proposal** flags about the
-current code. Whether they're actually "violations" depends on whether
-the proposal is adopted; listing them here as concerns to weigh, not
-as settled judgments.
+These primarily use the `covalence-shell::Kernel` backend and the object/store
+stack:
 
-1. **`covalence-kernel`'s Phase H bakes BLAKE3 into the kernel**
-   (`Arena::hash()`, `ContentHash` traits). The layered-framework
-   proposal argues this should be a hasher oracle outside the trust
-   boundary. See
-   [`design/proposals/layered-framework/02-framework.md` §6](./design/proposals/layered-framework/02-framework.md).
+- `cov repl`
+- `cov serve`
+- `packages/covalence-client`
+- `apps/covalence-web`
+- parts of `covalence-python`
+- `cov cog`
 
-2. **Phase P (Prop-as-egraph) layers equality saturation inside the
-   kernel.** The proposal argues egraphs belong in *userspace* as an
-   oracle that asserts equalities (which the framework then discharges
-   via cong+trans+sym), not as a framework primitive.
+### Theorem/proof-first surfaces
 
-3. **No store primitive.** The proposal argues crypto assumptions in
-   the current kernel have no honest scoping — they implicitly assume
-   "no collisions anywhere," which is mathematically false. See
-   [`design/proposals/layered-framework/04-store.md`](./design/proposals/layered-framework/04-store.md).
+These primarily care about prover traits or specific logic kernels:
 
-4. **No layered factoring.** Framework concerns (the LF rules), HOL
-   concerns (the existentials, subset typedef), and morphism concerns
-   (substitutions, imports) all live in one crate, hard to audit
-   independently.
+- `cov hol check`
+- `covalence-opentheory`
+- `covalence-alethe`
+- `covalence-egglog`
+- `covalence-metamath`
+- `covalence-lean`
+- parts of `covalence-python`
 
-5. **Three parallel kernels.** `covalence-kernel`, `covalence-hol`,
-   and the parts of `covalence-opentheory` that drive `covalence-hol`.
-   Need a single trusted core that they all factor through.
+That split is the clearest way to understand why several kernel lines coexist.
 
-6. **Application shells bind to a superseded kernel API.** REPL,
-   server, client, LSP all reason against `decide`/`attest()`. They
-   work, but they're not exercising the HOL kernel that's being built.
+## Build And Test Reality
 
----
+The checked-in commands currently line up like this:
 
-## 6. Where to look first
+### Root Bun scripts
 
-| If you want…                              | Read                                                                       |
-|-------------------------------------------|----------------------------------------------------------------------------|
-| The current logic/proof/translation zoo in one vocabulary | [`docs/institution-map.md`](./institution-map.md)                          |
-| The big picture / vision                  | [`ARCHITECTURE.md`](../ARCHITECTURE.md)                                    |
-| The **path** (substrate-first, two streams, kill list) | [`docs/design/proposals/shared-backbone/00-overview.md`](./design/proposals/shared-backbone/00-overview.md) |
-| The vocabulary the proposed redesign uses | [`docs/design/proposals/layered-framework/00-glossary.md`](./design/proposals/layered-framework/00-glossary.md)                    |
-| The smallest Paulson-style Pure/HOL sketch | [`docs/design/proposals/stacked-pure-hol/README.md`](./design/proposals/stacked-pure-hol/README.md)                               |
-| Conventions in the proposed redesign      | [`docs/design/proposals/layered-framework/01-conventions.md`](./design/proposals/layered-framework/01-conventions.md)              |
-| The proposed Framework layer              | [`docs/design/proposals/layered-framework/02-framework.md`](./design/proposals/layered-framework/02-framework.md)                  |
-| The proposal index                        | [`docs/design/proposals/layered-framework/README.md`](./design/proposals/layered-framework/README.md)                              |
-| The design directory index                | [`docs/design/README.md`](./design/README.md)                                                                                       |
-| Ongoing kernel cleanup (Phase A–H, P — *terminated*; see shared-backbone) | [`docs/refactor-plan.md`](./refactor-plan.md)                              |
-| Current kernel internals                  | [`docs/prover-architecture.md`](./prover-architecture.md)                  |
-| Current kernel build-out plan (*superseded by shared-backbone Phase 2*) | [`docs/prover-mvp-plan.md`](./prover-mvp-plan.md)                          |
-| The WASM-prop model (*seed of the WASM oracle*, not legacy) | [`MVP_DESIGN.md`](../MVP_DESIGN.md)                                        |
+- `bun run build` — native Rust binary plus VS Code WASM build
+- `bun run build:web` — web app only
+- `bun run build:serve` — web app plus native `cov` for embedded static serve
+- `bun run code:browser` / `bun run code:desktop` — extension workflows
+- `bun run build:python` — Python bindings via `maturin`
 
----
+### Testing
 
-## 7. What we're explicitly NOT doing yet
+- `cargo test`
+- `bun run test:ui`
+- `bun run test:wasm-js`
+- `bun run test:python`
 
-- **Wiping `covalence-kernel`** (the original "Phase 0 reset" from
-  `prover-mvp-plan.md`). The new layered crates will land alongside the
-  existing kernel; APIs migrate over once the layers are stable.
-- **Touching `covalence-hol` or `covalence-opentheory`.** Their
-  HOL-Light shape is the closest reference for the eventual
-  CovalenceHOL layer; we'll mine them for the port but not modify yet.
-- **Producing the first end-to-end demo.** Per the planning
-  discussion, the target is the **Git-repo theorem** (clone, re-hash
-  to BLAKE3, prove things about a commit under a scoped no-collision
-  assumption), but it builds on the framework crate which doesn't
-  exist yet.
+There is currently no single top-level JS “run everything” script.
 
----
+## What Is Stable Vs Transitional
 
-## 8. Recent changes worth noting
+### Relatively stable
 
-From `git log` on `planning-stage` (most recent first):
+- the store/object/hash substrate
+- the server, REPL, and TypeScript client surface
+- the VS Code and web application scaffolding
+- the existence of multiple logic/import families
 
-- `6206676` — `Cargo.lock: covalence-kernel picks up covalence-hash dep`
-- `f3bccac` — `docs: update refactor-plan with Phase P/H actual landing`
-- `6056e99` — `kernel: VarId / TyVarId newtypes + per-arena allocators (Phase F1)`
-- `08e6d94` — `kernel: content hashing for Arena, Prop, EProp (Phase H)`
-- `c2218bd` — `kernel: declare_type_operator validates tyvar ordering (Phase G3)`
+### Clearly transitional
 
-Phase H (content hashing) is the most recent substantive landing and
-also the most architecturally questionable. The decision to move it
-*out* of the trust boundary is captured in
-[`docs/design/02-framework.md` §6](./design/02-framework.md).
+- which prover/kernel line becomes the long-term center
+- how `covalence-kernel`, `covalence-pure`, and `covalence-hol` eventually
+  relate
+- how much of the current `Prover` surface stays identical through that change
+- which proposal set from `docs/design/` becomes adopted architecture
+
+## How To Read The Rest Of The Docs
+
+- Use [`c4.md`](./c4.md) for the current component map.
+- Use [`institution-map.md`](./institution-map.md) if your work crosses logic
+  families or importers.
+- Use [`design/README.md`](./design/README.md) for future-direction proposals.
+- Use [`../ARCHITECTURE.md`](../ARCHITECTURE.md) and
+  [`../AGENTS.md`](../AGENTS.md) as the target constraints, not as a literal
+  description of every current crate boundary.


### PR DESCRIPTION
## Summary
- rewrite the top-level docs to describe the repo as it exists now
- replace the stale planning-stage current-state docs with a code-first snapshot
- clarify that covalence-pure still exists and that the removed piece was the old HolPrim adapter path

## Testing
- not run (docs-only changes)