### PR TITLE
covalence-hol/init/rat: lift the rat quotient definition

### DIFF
--- a/SKELETONS.md
+++ b/SKELETONS.md
@@ -73,16 +73,34 @@ it is how unfinished work stays discoverable.
     that lands, this becomes the int-analogue of `int_rel_trans`.
   - The ordered-field axioms over `rat_zero`/`rat_one`/`rat_add`/
     `rat_neg`/`rat_mul`/`rat_lt` (commutative-ring `add_*`/`mul_*`/
-    `distrib`, multiplicative inverse `mul_inv`, and the linear order
-    `lt_*`/`le_def`). Each is a HOL theorem derivable from the `int`
-    ordered-ring theory through the quotient; filling them in does not
-    change the public `fn` surface. They depend transitively on the
-    `int` postulates above.
+    `distrib`, multiplicative inverse `mul_inv`, the linear order
+    `lt_*`/`le_def`, and the base strictness fact `zero_lt_one` — `ratLt`
+    picks ε-representatives, so `0 < 1` is not reducible). Each is a HOL
+    theorem derivable from the `int` ordered-ring theory through the
+    quotient; filling them in does not change the public `fn` surface.
+    They depend transitively on the `int` postulates above. (The `≤`
+    toolkit `le_refl`/`lt_imp_le`/`le_trans`/`not_one_le_zero` is **not**
+    postulated — it is *derived* from `le_def` + the strict-order facts.)
   - The two **mediant inequalities** `mediant_gt` / `mediant_lt` — the
     only postulated leaves of `dense` (which is itself *derived* from
     them via the mediant `(a+c)/(b+d)`, no division needed). Each unfolds
     to an `int` order fact (`a·d < c·b ⟹ a·(b+d) < (a+c)·b`, etc.)
     lifted through the quotient — blocked on the same `int` order theory.
+
+- **The `real` Dedekind-cut theory** in
+  `crates/covalence-hol/src/init/real.rs`. `real := close rat ratLe`
+  (upper cuts). **Proved**: `is_cut` (every principal up-set `ratLe q` is a
+  genuine cut, from the `rat` `≤` toolkit) and `zero_ne_one` (`⊢ ¬(0 = 1)`,
+  via distinct principal cuts transported through the subtype `rep`/`abs`).
+  Both are genuine *modulo* the `rat` order postulates they consume.
+  **Postulated** via the module's `axiom` helper (self-flagged):
+  - `sup_is_ub` / `sup_is_least` — the two least-upper-bound properties of
+    the supremum cut `real_sup A` (the intersection of the members'
+    cut-sets). Each unfolds to a set/order fact about the cuts, blocked on
+    the same `rat`/order theory. `complete` (the least-upper-bound property,
+    "the reals are complete") is itself **derived** from these two, with
+    `real_sup A` as the witness — the direct analogue of how `rat::dense`
+    is derived from its mediant postulates.
 
 ## Partial subsystems
 

--- a/SKELETONS.md
+++ b/SKELETONS.md
@@ -61,6 +61,29 @@ it is how unfinished work stays discoverable.
     `mul_succ_r` / `mul_comm` / `mul_assoc` / `distrib`, and the `le`/`lt`
     order facts. `init::nat` already has the additive theory, `add_cancel`,
     `add_interchange`, and `mul_zero`.
+- **The `rat` quotient + ordered-field theory** in
+  `crates/covalence-hol/src/init/rat.rs`. `rat := (int × int.pos) / ~`
+  (cross-multiplication). Proved outright: `rat_rel_refl`, `rat_rel_symm`
+  (pure `int`-equation `refl`/`sym`), and `of_nat_via_int` (the ℕ↪ℚ
+  embedding factors through ℤ↪ℚ, by β). **Postulated** via the module's
+  `axiom` helper (each carrying its statement as a self-hyp):
+  - `rat_rel_trans` — transitivity of the cross-multiplication relation.
+    Needs `int` *multiplicative cancellation by a positive* (cancel the
+    common positive denominator), an `int` fact not yet discharged. Once
+    that lands, this becomes the int-analogue of `int_rel_trans`.
+  - The ordered-field axioms over `rat_zero`/`rat_one`/`rat_add`/
+    `rat_neg`/`rat_mul`/`rat_lt` (commutative-ring `add_*`/`mul_*`/
+    `distrib`, multiplicative inverse `mul_inv`, and the linear order
+    `lt_*`/`le_def`). Each is a HOL theorem derivable from the `int`
+    ordered-ring theory through the quotient; filling them in does not
+    change the public `fn` surface. They depend transitively on the
+    `int` postulates above.
+  - The two **mediant inequalities** `mediant_gt` / `mediant_lt` — the
+    only postulated leaves of `dense` (which is itself *derived* from
+    them via the mediant `(a+c)/(b+d)`, no division needed). Each unfolds
+    to an `int` order fact (`a·d < c·b ⟹ a·(b+d) < (a+c)·b`, etc.)
+    lifted through the quotient — blocked on the same `int` order theory.
+
 ## Partial subsystems
 
 - **`covalence-alethe` rule coverage.** `HolAletheBridge` (in

--- a/crates/covalence-hol/src/init/mod.rs
+++ b/crates/covalence-hol/src/init/mod.rs
@@ -23,7 +23,7 @@
 //! - [`set`] — the `TypeSpec`-backed set membership / extensionality API.
 //!
 //! plus the per-theory theorem catalogues — [`cond`] (the boolean
-//! conditional's reduction clauses), [`nat`], [`int`], [`rat`],
+//! conditional's reduction clauses), [`nat`], [`int`], [`rat`], [`real`],
 //! [`coprod`], [`option`], [`stream`], [`recursion`], [`rel`], and
 //! [`set`].
 //!
@@ -64,6 +64,7 @@ pub mod nat;
 pub mod option;
 pub mod quotient;
 pub mod rat;
+pub mod real;
 pub mod recursion;
 pub mod rel;
 pub mod set;

--- a/crates/covalence-hol/src/init/mod.rs
+++ b/crates/covalence-hol/src/init/mod.rs
@@ -23,8 +23,9 @@
 //! - [`set`] — the `TypeSpec`-backed set membership / extensionality API.
 //!
 //! plus the per-theory theorem catalogues — [`cond`] (the boolean
-//! conditional's reduction clauses), [`nat`], [`int`], [`coprod`],
-//! [`option`], [`stream`], [`recursion`], [`rel`], and [`set`].
+//! conditional's reduction clauses), [`nat`], [`int`], [`rat`],
+//! [`coprod`], [`option`], [`stream`], [`recursion`], [`rel`], and
+//! [`set`].
 //!
 //! Efficiency is explicitly *not* a goal: `init` runs once at startup.
 //! The point is for the rest of `covalence-hol` to depend on this
@@ -62,6 +63,7 @@ pub mod coprod;
 pub mod nat;
 pub mod option;
 pub mod quotient;
+pub mod rat;
 pub mod recursion;
 pub mod rel;
 pub mod set;

--- a/crates/covalence-hol/src/init/rat.rs
+++ b/crates/covalence-hol/src/init/rat.rs
@@ -48,7 +48,7 @@ use covalence_core::defs::{fst, int_pos_spec, int_pos_ty, prod, snd};
 use covalence_core::{Result, Term, Thm, Type, subst};
 
 use crate::init::ext::TermExt;
-use crate::init::{int, nat};
+use crate::init::{int, logic, nat};
 
 // Re-export the `defs/rat.rs` catalogue (the type handles + the declared
 // `ratLe` order constant; bodies stay in `covalence_core::defs`).
@@ -444,6 +444,158 @@ pub fn mul_inv() -> Thm {
     axiom(forall_rat(&["a"], body))
 }
 
+// ============================================================================
+// Strict order — defined via cross-multiplication; linear-order axioms
+// postulated
+// ============================================================================
+
+/// `a < b` on `int`.
+fn ilt(a: Term, b: Term) -> Term {
+    Term::app(Term::app(int::int_lt(), a), b)
+}
+
+/// `ratLt : rat → rat → bool` ≡ `(a/b) < (c/d) ⟺ a·d < c·b` (valid
+/// because denominators are strictly positive). Defined here at the
+/// representative level — `defs/rat.rs` ships only the declaration-only
+/// `ratLe`; `<` is the strict companion the density statement is phrased
+/// in.
+pub fn rat_lt() -> Term {
+    let (x, y) = (Term::free("x", rat()), Term::free("y", rat()));
+    let (px, py) = (rep_pair(x.clone()), rep_pair(y.clone()));
+    let body = ilt(imul(num(&px), den(&py)), imul(num(&py), den(&px)));
+    Term::abs(rat(), subst::close(&Term::abs(rat(), subst::close(&body, "y")), "x"))
+}
+
+/// `a < b` on `rat`.
+fn rlt(a: Term, b: Term) -> Term {
+    Term::app(Term::app(rat_lt(), a), b)
+}
+/// `a ≤ b` on `rat` (the declared kernel `ratLe`).
+fn rle(a: Term, b: Term) -> Term {
+    Term::app(Term::app(rat_le(), a), b)
+}
+
+/// `⊢ ∀a. ¬(a < a)` — irreflexivity.
+pub fn lt_irrefl() -> Thm {
+    let a = rvar("a");
+    axiom(forall_rat(&["a"], rlt(a.clone(), a).not().expect("lt_irrefl")))
+}
+
+/// `⊢ ∀a b c. a < b ⟹ b < c ⟹ a < c` — transitivity.
+pub fn lt_trans() -> Thm {
+    let (a, b, c) = (rvar("a"), rvar("b"), rvar("c"));
+    let inner = rlt(b.clone(), c.clone())
+        .imp(rlt(a.clone(), c))
+        .expect("lt_trans inner");
+    let body = rlt(a, b).imp(inner).expect("lt_trans");
+    axiom(forall_rat(&["a", "b", "c"], body))
+}
+
+/// `⊢ ∀a b. a < b ∨ a = b ∨ b < a` — trichotomy (totality).
+pub fn lt_trichotomy() -> Thm {
+    let (a, b) = (rvar("a"), rvar("b"));
+    let eq = a.clone().equals(b.clone()).expect("trichotomy: a = b");
+    let tail = eq.or(rlt(b.clone(), a.clone())).expect("trichotomy tail");
+    let body = rlt(a, b).or(tail).expect("trichotomy");
+    axiom(forall_rat(&["a", "b"], body))
+}
+
+/// `⊢ ∀a b. (a ≤ b) = (a < b ∨ a = b)` — `≤` in terms of `<`.
+pub fn le_def() -> Thm {
+    let (a, b) = (rvar("a"), rvar("b"));
+    let rhs = rlt(a.clone(), b.clone())
+        .or(a.clone().equals(b.clone()).expect("le_def: a = b"))
+        .expect("le_def rhs");
+    let eq = rle(a, b).equals(rhs).expect("le_def");
+    axiom(forall_rat(&["a", "b"], eq))
+}
+
+// ============================================================================
+// Density — DERIVED from the two mediant inequalities
+// ============================================================================
+//
+// The witness between `x < y` is the **mediant** `(a+c)/(b+d)` of
+// representatives `x = a/b`, `y = c/d` — strictly between `x` and `y`
+// exactly when `x < y`, and (unlike the midpoint `(x+y)/2`) needing no
+// division to construct. The two mediant inequalities are the postulated
+// leaves; `dense` itself is a genuine derivation from them.
+
+/// `ratMediant : rat → rat → rat` ≡ `(a/b) ⊕ (c/d) = (a+c)/(b+d)`.
+pub fn mediant() -> Term {
+    binary_rat(|px, py| {
+        ip(iadd(num(px), num(py)), to_pos(iadd(den(px), den(py))))
+    })
+}
+/// `mediant a b` applied.
+fn med(a: Term, b: Term) -> Term {
+    Term::app(Term::app(mediant(), a), b)
+}
+
+/// `⊢ ∀x y. x < y ⟹ x < mediant x y` — the mediant exceeds the smaller.
+///
+/// **Postulated** (audit hyp). Unfolds to the `int` order fact
+/// `a·d < c·b ⟹ a·(b+d) < (a+c)·b` lifted through the quotient — blocked
+/// on the `int` ordered-ring theory (`SKELETONS.md`).
+pub fn mediant_gt() -> Thm {
+    let (x, y) = (rvar("x"), rvar("y"));
+    let concl = rlt(x.clone(), med(x.clone(), y.clone()));
+    let body = rlt(x, y).imp(concl).expect("mediant_gt");
+    axiom(forall_rat(&["x", "y"], body))
+}
+
+/// `⊢ ∀x y. x < y ⟹ mediant x y < y` — the mediant is below the larger.
+///
+/// **Postulated** (audit hyp) — the mirror of [`mediant_gt`].
+pub fn mediant_lt() -> Thm {
+    let (x, y) = (rvar("x"), rvar("y"));
+    let concl = rlt(med(x.clone(), y.clone()), y.clone());
+    let body = rlt(x, y).imp(concl).expect("mediant_lt");
+    axiom(forall_rat(&["x", "y"], body))
+}
+
+cached_thm! {
+    /// `⊢ ∀x y. x < y ⟹ ∃z. x < z ∧ z < y` — **the rationals are dense.**
+    ///
+    /// A genuine derivation: the mediant `z = mediant x y` is the witness,
+    /// `mediant_gt` / `mediant_lt` give the two strict inequalities, and
+    /// `∃`-introduction + `∧`-introduction package them. The only
+    /// postulated leaves are the two mediant inequalities; once they are
+    /// discharged this theorem is hypothesis-free.
+    pub fn dense() -> Thm {
+        dense_impl().expect("dense derivation")
+    }
+}
+fn dense_impl() -> Result<Thm> {
+    let (x, y) = (rvar("x"), rvar("y"));
+    let m = med(x.clone(), y.clone());
+    let hyp = rlt(x.clone(), y.clone());
+    let h = Thm::assume(hyp.clone())?;
+
+    // {x<y} ⊢ x < m   and   {x<y} ⊢ m < y.
+    let gt = mediant_gt()
+        .all_elim(x.clone())?
+        .all_elim(y.clone())?
+        .imp_elim(h.clone())?;
+    let lt = mediant_lt()
+        .all_elim(x.clone())?
+        .all_elim(y.clone())?
+        .imp_elim(h)?;
+    let conj = gt.and_intro(lt)?; // {x<y} ⊢ x < m ∧ m < y
+
+    // ∃z. x < z ∧ z < y, with witness `m`.
+    let z = rvar("z");
+    let pred_body = rlt(x.clone(), z.clone()).and(rlt(z.clone(), y.clone()))?;
+    let pred = Term::abs(rat(), subst::close(&pred_body, "z"));
+    let pf = Thm::beta_conv(Term::app(pred.clone(), m.clone()))?
+        .sym()?
+        .eq_mp(conj)?; // {x<y} ⊢ pred m
+    let ex = logic::exists_intro(pred, m, pf)?; // {x<y} ⊢ ∃z. x<z ∧ z<y
+
+    ex.imp_intro(&hyp)?
+        .all_intro("y", rat())?
+        .all_intro("x", rat())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -584,6 +736,59 @@ mod tests {
             .equals(radd(two, one))
             .unwrap();
         assert_eq!(inst.concl(), &expected);
+    }
+
+    #[test]
+    fn order_axioms_are_well_typed_and_self_flagged() {
+        for ax in [lt_irrefl(), lt_trans(), lt_trichotomy(), le_def()] {
+            assert!(ax.concl().type_of().unwrap().is_bool());
+            assert!(ax.hyps().iter().any(|h| h == ax.concl()));
+        }
+    }
+
+    #[test]
+    fn rat_lt_and_mediant_have_expected_types() {
+        let r = rat();
+        assert_eq!(
+            rat_lt().type_of().unwrap(),
+            Type::fun(r.clone(), Type::fun(r.clone(), Type::bool()))
+        );
+        assert_eq!(
+            mediant().type_of().unwrap(),
+            Type::fun(r.clone(), Type::fun(r.clone(), r))
+        );
+    }
+
+    #[test]
+    fn dense_is_derived_from_the_mediant_postulates() {
+        let thm = dense();
+        // The statement: ∀x y. x < y ⟹ ∃z. x < z ∧ z < y.
+        let (x, y) = (rvar("x"), rvar("y"));
+        let inst = thm
+            .clone()
+            .all_elim(x.clone())
+            .and_then(|t| t.all_elim(y.clone()))
+            .unwrap();
+        // The consequent of the (instantiated) implication is an ∃.
+        let (ante, conseq) = {
+            let c = inst.concl();
+            // c = (x < y) ⟹ ∃z. …
+            let (head, conseq) = c.as_app().unwrap();
+            let (_imp, ante) = head.as_app().unwrap();
+            (ante.clone(), conseq.clone())
+        };
+        assert_eq!(ante, rlt(x, y));
+        // The consequent is `exists[rat] pred`.
+        let head = conseq.as_app().expect("consequent is an application").0;
+        assert_eq!(head, &covalence_core::defs::exists(rat()));
+
+        // dense is genuine *modulo* exactly the two mediant postulates: it
+        // carries them (and nothing else) as hypotheses.
+        let hyps = thm.hyps();
+        assert_eq!(hyps.len(), 2, "only the two mediant postulates remain");
+        for h in hyps {
+            assert!(h.type_of().unwrap().is_bool());
+        }
     }
 
     #[test]

--- a/crates/covalence-hol/src/init/rat.rs
+++ b/crates/covalence-hol/src/init/rat.rs
@@ -45,10 +45,10 @@
 //!   mediant `(a+c)/(b+d)`, the witness that needs no division.
 
 use covalence_core::defs::{fst, int_pos_spec, int_pos_ty, prod, snd};
-use covalence_core::{Result, Term, Thm, Type};
+use covalence_core::{Result, Term, Thm, Type, subst};
 
 use crate::init::ext::TermExt;
-use crate::init::int;
+use crate::init::{int, nat};
 
 // Re-export the `defs/rat.rs` catalogue (the type handles + the declared
 // `ratLe` order constant; bodies stay in `covalence_core::defs`).
@@ -112,23 +112,150 @@ fn mk_rat(p: &Term) -> Term {
     crate::init::quotient::mk_class(&rat_spec(), &[], &ip_pair(), &rat_rel(), p)
 }
 
+/// `⊢ rat_rel p q` → `⊢ <β-reduced cross-mult equation>`.
+fn reduce_rel(thm: Thm) -> Result<Thm> {
+    thm.concl().reduce()?.eq_mp(thm)
+}
+
+/// `⊢ <β-reduced cross-mult equation>` → `⊢ rat_rel p q`, for the given
+/// application.
+fn expand_rel(eq: Thm, app: &Term) -> Result<Thm> {
+    app.reduce()?.sym()?.eq_mp(eq)
+}
+
+/// `1 : int.pos` — the abstraction of the `int` literal `1`. The
+/// canonical denominator for the integer / rational embeddings.
+fn one_pos() -> Term {
+    Term::app(Term::spec_abs(int_pos_spec(), Vec::new()), Term::int_lit(1i128))
+}
+
+/// `pair a b : int × int.pos`.
+fn ip(a: Term, b: Term) -> Term {
+    Term::app(
+        Term::app(covalence_core::defs::pair(Type::int(), int_pos_ty()), a),
+        b,
+    )
+}
+
+/// Postulate a `rat` axiom: `{t} ⊢ t`. The self-hypothesis is the audit
+/// trail — every proof built on it carries it, flagging the unproved leaf
+/// until the quotient derivation discharges it (cf. `init::int::axiom`).
+fn axiom(t: Term) -> Thm {
+    Thm::assume(t).expect("init::rat::axiom: term must be bool-typed")
+}
+
+/// Universally close `body` over the named representative-pair variables,
+/// outermost first.
+fn forall_pair(vars: &[&str], body: Term) -> Term {
+    let mut t = body;
+    for name in vars.iter().rev() {
+        t = t.forall(name, ip_pair()).expect("forall_pair: bind variable");
+    }
+    t
+}
+
+// ============================================================================
+// `rat_rel` is an equivalence
+// ============================================================================
+//
+// `refl` / `symm` are pure `int`-equation manipulations of the cross-
+// multiplication body and are **proved** outright. `trans` is the one
+// piece that needs `int` *multiplicative cancellation by a positive*
+// denominator (from `a·d = c·b` and `c·f = e·d`, cancel `d` to reach
+// `a·f = e·b`); that `int` fact is not yet discharged, so `trans` is a
+// postulate (`SKELETONS.md`).
+
+cached_thm! {
+    /// `⊢ ∀p. rat_rel p p` — reflexivity (`num p · den p = num p · den p`).
+    pub fn rat_rel_refl() -> Thm {
+        rat_rel_refl_impl().expect("rat_rel_refl")
+    }
+}
+fn rat_rel_refl_impl() -> Result<Thm> {
+    let p = Term::free("p", ip_pair());
+    let reduced = Thm::refl(imul(num(&p), den(&p)))?;
+    expand_rel(reduced, &rel_app(&p, &p))?.all_intro("p", ip_pair())
+}
+
+cached_thm! {
+    /// `⊢ ∀p q. rat_rel p q ⟹ rat_rel q p` — symmetry (`sym` of the
+    /// defining cross-multiplication equation).
+    pub fn rat_rel_symm() -> Thm {
+        rat_rel_symm_impl().expect("rat_rel_symm")
+    }
+}
+fn rat_rel_symm_impl() -> Result<Thm> {
+    let (p, q) = (Term::free("p", ip_pair()), Term::free("q", ip_pair()));
+    let hyp = rel_app(&p, &q);
+    let flipped = reduce_rel(Thm::assume(hyp.clone())?)?.sym()?; // ⊢ num q·den p = num p·den q
+    expand_rel(flipped, &rel_app(&q, &p))?
+        .imp_intro(&hyp)?
+        .all_intro("q", ip_pair())?
+        .all_intro("p", ip_pair())
+}
+
+cached_thm! {
+    /// `⊢ ∀p q r. rat_rel p q ⟹ rat_rel q r ⟹ rat_rel p r` —
+    /// transitivity.
+    ///
+    /// **Postulated** (audit hyp). The derivation: from `num p · den q =
+    /// num q · den p` and `num q · den r = num r · den q`, multiply the
+    /// first by `den r` and the second by `den p`, commute/associate so
+    /// the common `num q · den q · den r` factor matches, giving
+    /// `(num p · den r) · den q = (num r · den p) · den q`, then cancel
+    /// `den q` (strictly positive, hence nonzero) — the `int`
+    /// multiplicative cancellation that is not yet a proved `int` fact.
+    pub fn rat_rel_trans() -> Thm {
+        let (p, q, r) = (
+            Term::free("p", ip_pair()),
+            Term::free("q", ip_pair()),
+            Term::free("r", ip_pair()),
+        );
+        let pr = rel_app(&p, &r);
+        let body = rel_app(&p, &q)
+            .imp(rel_app(&q, &r).imp(pr).expect("rat_rel_trans inner"))
+            .expect("rat_rel_trans");
+        axiom(forall_pair(&["p", "q", "r"], body))
+    }
+}
+
+// ============================================================================
+// Maps in: ℤ ↪ ℚ and ℕ ↪ ℚ (the latter by composition)
+// ============================================================================
+
+/// `of_int : int → rat` ≡ `λa. mkRat (a, 1)` — the ring embedding of the
+/// integers (numerator `a`, denominator `1`).
+pub fn of_int() -> Term {
+    let a = Term::free("a", Type::int());
+    let body = mk_rat(&ip(a.clone(), one_pos()));
+    Term::abs(Type::int(), subst::close(&body, "a"))
+}
+
+/// `of_nat : nat → rat` ≡ `λn. of_int (nat.toInt n)` — the embedding of
+/// the naturals, **by composition** through `of_int` and the nat→int
+/// coercion.
+pub fn of_nat() -> Term {
+    let n = Term::free("n", Type::nat());
+    let body = Term::app(of_int(), Term::app(nat::nat_to_int(), n.clone()));
+    Term::abs(Type::nat(), subst::close(&body, "n"))
+}
+
+cached_thm! {
+    /// `⊢ ∀n. of_nat n = of_int (nat.toInt n)` — the naturals embed
+    /// through the integers (the defining composition, by β).
+    pub fn of_nat_via_int() -> Thm {
+        of_nat_via_int_impl().expect("of_nat_via_int")
+    }
+}
+fn of_nat_via_int_impl() -> Result<Thm> {
+    let n = Term::free("n", Type::nat());
+    let redex = Term::app(of_nat(), n.clone()); // (λn. of_int (toInt n)) n
+    Thm::beta_conv(redex)?.all_intro("n", Type::nat())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// `pair a b : int × int.pos` from an `int` numerator and an
-    /// `int.pos` denominator.
-    fn ip(a: Term, b: Term) -> Term {
-        Term::app(
-            Term::app(covalence_core::defs::pair(Type::int(), int_pos_ty()), a),
-            b,
-        )
-    }
-
-    /// `1 : int.pos` — the abstraction of the `int` literal `1`.
-    fn one_pos() -> Term {
-        Term::app(Term::spec_abs(int_pos_spec(), Vec::new()), Term::int_lit(1i128))
-    }
 
     #[test]
     fn rat_ty_matches_the_catalogue() {
@@ -162,5 +289,74 @@ mod tests {
     fn mk_rat_is_a_rational() {
         let p = ip(Term::int_lit(5i128), one_pos());
         assert_eq!(mk_rat(&p).type_of().unwrap(), rat());
+    }
+
+    #[test]
+    fn rat_rel_refl_and_symm_are_genuine() {
+        // refl / symm are proved outright (no hypotheses).
+        for t in [rat_rel_refl(), rat_rel_symm()] {
+            assert!(t.hyps().is_empty(), "rat_rel refl/symm are proved");
+            assert!(t.concl().type_of().unwrap().is_bool());
+        }
+        let (p, q) = (Term::free("p", ip_pair()), Term::free("q", ip_pair()));
+        assert_eq!(rat_rel_refl().all_elim(p.clone()).unwrap().concl(), &rel_app(&p, &p));
+        let symm = rat_rel_symm()
+            .all_elim(p.clone())
+            .unwrap()
+            .all_elim(q.clone())
+            .unwrap();
+        assert_eq!(symm.concl(), &rel_app(&p, &q).imp(rel_app(&q, &p)).unwrap());
+    }
+
+    #[test]
+    fn rat_rel_trans_is_a_self_flagged_postulate() {
+        let t = rat_rel_trans();
+        assert!(t.concl().type_of().unwrap().is_bool());
+        assert!(
+            t.hyps().iter().any(|h| h == t.concl()),
+            "the postulate carries itself as a hypothesis"
+        );
+    }
+
+    #[test]
+    fn class_intro_lifts_rat_rel_to_a_class_equation() {
+        // With symm proved and trans postulated, the forward quotient law
+        // lifts a `~`-fact to a rat-class equation over the real spec.
+        use crate::init::quotient;
+        let (p, q) = (Term::free("p", ip_pair()), Term::free("q", ip_pair()));
+        let ab = Thm::assume(rel_app(&p, &q)).unwrap();
+        let lifted = quotient::class_intro(
+            &rat_spec(),
+            &[],
+            &ip_pair(),
+            &rat_rel_symm(),
+            &rat_rel_trans(),
+            ab,
+        )
+        .expect("class_intro on rat_rel");
+        let (l, r) = lifted.concl().as_eq().expect("lifted to a class equation");
+        assert_eq!(l, &mk_rat(&p));
+        assert_eq!(r, &mk_rat(&q));
+        assert!(lifted.hyps().iter().any(|h| h == &rel_app(&p, &q)));
+    }
+
+    #[test]
+    fn maps_have_the_expected_types() {
+        assert_eq!(of_int().type_of().unwrap(), Type::fun(Type::int(), rat()));
+        assert_eq!(of_nat().type_of().unwrap(), Type::fun(Type::nat(), rat()));
+    }
+
+    #[test]
+    fn of_nat_factors_through_of_int() {
+        // ∀n. of_nat n = of_int (nat.toInt n); specialise to a concrete n.
+        let n = Term::free("k", Type::nat());
+        let inst = of_nat_via_int().all_elim(n.clone()).unwrap();
+        let lhs = Term::app(of_nat(), n.clone());
+        let rhs = Term::app(of_int(), Term::app(nat::nat_to_int(), n));
+        // of_nat_via_int is a β-fact: genuine, hypothesis-free.
+        assert!(of_nat_via_int().hyps().is_empty());
+        let (l, r) = inst.concl().as_eq().unwrap();
+        assert_eq!(l, &lhs);
+        assert_eq!(r, &rhs);
     }
 }

--- a/crates/covalence-hol/src/init/rat.rs
+++ b/crates/covalence-hol/src/init/rat.rs
@@ -1,0 +1,166 @@
+//! `rat` theorems: the `defs/rat.rs` catalogue re-exported, plus the
+//! quotient scaffolding for HOL `rat := (int × int.pos) / ~` — mirroring
+//! how [`init::int`] pairs the `int` definitions with the Grothendieck
+//! quotient machinery, one level up.
+//!
+//! [`init::int`]: crate::init::int
+//!
+//! ## The construction
+//!
+//! A pair `(a, b) : int × int.pos` represents the rational `a / b` with a
+//! strictly-positive denominator (so it is always nonzero and the sign
+//! lives in the numerator), and pairs are identified by
+//! cross-multiplication:
+//!
+//! ```text
+//!     (a, b) ~ (c, d)  ⟺  a · d = c · b
+//! ```
+//!
+//! `rat` is the quotient of `prod int int.pos` by that relation; the
+//! carrier is `(prod int int.pos) → bool` (a class is the set of
+//! equivalent numerator/denominator pairs). The bridge between a
+//! representative pair and its class reuses the generic
+//! [`init::quotient`](crate::init::quotient) machinery exactly as `int`
+//! does over `nat × nat`.
+//!
+//! ## Status
+//!
+//! This module is built up in layers, mirroring `init::int`:
+//!
+//! - **Quotient relation.** [`rat_rel`] is the cross-multiplication
+//!   relation, structurally the term `defs/rat.rs` quotients by.
+//!   [`rat_rel_refl`] / [`rat_rel_symm`] are **proved** (`int`-equation
+//!   `refl` / `sym`); [`rat_rel_trans`] is **postulated** — it is the one
+//!   piece that needs `int` *multiplicative cancellation by a positive*,
+//!   an `int` fact not yet discharged (see `SKELETONS.md`).
+//! - **Maps in.** [`of_int`] (`a ↦ a/1`) and [`of_nat`] (`= of_int ∘
+//!   nat.toInt`, by composition) embed the integers and naturals.
+//! - **Ring / order.** The field operations ([`rat_zero`], [`rat_one`],
+//!   [`rat_add`], [`rat_neg`], [`rat_mul`]) and the strict order
+//!   ([`rat_lt`]) are defined at the representative level; the ordered-
+//!   field axioms over them are **postulated** (same audit-trail style as
+//!   `init::int`), pending the quotient derivations.
+//! - **Density.** [`dense`] — `∀x y. x < y ⟹ ∃z. x < z ∧ z < y` — is
+//!   **derived** from the two mediant-inequality postulates via the
+//!   mediant `(a+c)/(b+d)`, the witness that needs no division.
+
+use covalence_core::defs::{fst, int_pos_spec, int_pos_ty, prod, snd};
+use covalence_core::{Result, Term, Thm, Type};
+
+use crate::init::ext::TermExt;
+use crate::init::int;
+
+// Re-export the `defs/rat.rs` catalogue (the type handles + the declared
+// `ratLe` order constant; bodies stay in `covalence_core::defs`).
+pub use covalence_core::defs::{rat_le, rat_le_spec, rat_spec, rat_ty};
+
+// ============================================================================
+// Small term helpers (private — the public surface is theorems / maps)
+// ============================================================================
+
+/// `rat` — the rationals type.
+fn rat() -> Type {
+    rat_ty()
+}
+
+/// `int × int.pos` — the numerator/denominator representative carrier.
+fn ip_pair() -> Type {
+    prod(Type::int(), int_pos_ty())
+}
+
+/// `fst p : int` — the numerator of a representative pair.
+fn num(p: &Term) -> Term {
+    Term::app(fst(Type::int(), int_pos_ty()), p.clone())
+}
+
+/// `rep (snd p) : int` — the (positive) denominator of a representative
+/// pair, coerced from `int.pos` down to its underlying `int`.
+fn den(p: &Term) -> Term {
+    let d_pos = Term::app(snd(Type::int(), int_pos_ty()), p.clone());
+    let rep = Term::spec_rep(int_pos_spec(), Vec::new());
+    Term::app(rep, d_pos)
+}
+
+/// `a · b` on `int`.
+fn imul(a: Term, b: Term) -> Term {
+    Term::app(Term::app(int::int_mul(), a), b)
+}
+
+/// `λp q. num p · den q = num q · den p` — the cross-multiplication
+/// relation carving `rat`. Structurally the same term `defs/rat.rs`
+/// quotients by.
+pub fn rat_rel() -> Term {
+    let pair_ty = ip_pair();
+    let (p, q) = (Term::free("p", pair_ty.clone()), Term::free("q", pair_ty.clone()));
+    let body = imul(num(&p), den(&q))
+        .equals(imul(num(&q), den(&p)))
+        .expect("rat_rel: body");
+    let inner = Term::abs(pair_ty.clone(), covalence_core::subst::close(&body, "q"));
+    Term::abs(pair_ty, covalence_core::subst::close(&inner, "p"))
+}
+
+/// `rat_rel p q` as an (un-reduced) application — the shape
+/// [`quotient::class_intro`](crate::init::quotient::class_intro) reads
+/// its relation in.
+fn rel_app(p: &Term, q: &Term) -> Term {
+    Term::app(Term::app(rat_rel(), p.clone()), q.clone())
+}
+
+/// `mkRat p ≔ abs (λq. rat_rel p q)` — the rational whose class is `[p]`,
+/// for a representative pair term `p : int × int.pos`.
+fn mk_rat(p: &Term) -> Term {
+    crate::init::quotient::mk_class(&rat_spec(), &[], &ip_pair(), &rat_rel(), p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `pair a b : int × int.pos` from an `int` numerator and an
+    /// `int.pos` denominator.
+    fn ip(a: Term, b: Term) -> Term {
+        Term::app(
+            Term::app(covalence_core::defs::pair(Type::int(), int_pos_ty()), a),
+            b,
+        )
+    }
+
+    /// `1 : int.pos` — the abstraction of the `int` literal `1`.
+    fn one_pos() -> Term {
+        Term::app(Term::spec_abs(int_pos_spec(), Vec::new()), Term::int_lit(1i128))
+    }
+
+    #[test]
+    fn rat_ty_matches_the_catalogue() {
+        // The re-exported `rat` type is the `defs/rat.rs` one, and not bool.
+        assert_eq!(rat(), covalence_core::defs::rat_ty());
+        assert!(!rat().is_bool());
+    }
+
+    #[test]
+    fn rat_rel_is_a_binary_relation_on_pairs() {
+        // rat_rel : (int×int.pos) → (int×int.pos) → bool.
+        let expected = Type::fun(
+            ip_pair(),
+            Type::fun(ip_pair(), Type::bool()),
+        );
+        assert_eq!(rat_rel().type_of().unwrap(), expected);
+    }
+
+    #[test]
+    fn rel_app_reduces_to_a_cross_multiplication() {
+        // rat_rel (a,1) (c,1)  β-reduces to  a·den(c,1) = c·den(a,1).
+        let p = ip(Term::int_lit(2i128), one_pos());
+        let q = ip(Term::int_lit(3i128), one_pos());
+        let reduced = rel_app(&p, &q).reduce().unwrap();
+        // The reduct is a bool equation between two int products.
+        let rhs = reduced.concl().as_eq().unwrap().1;
+        assert!(rhs.as_eq().is_some(), "reduct is `_ · _ = _ · _`");
+    }
+
+    #[test]
+    fn mk_rat_is_a_rational() {
+        let p = ip(Term::int_lit(5i128), one_pos());
+        assert_eq!(mk_rat(&p).type_of().unwrap(), rat());
+    }
+}

--- a/crates/covalence-hol/src/init/rat.rs
+++ b/crates/covalence-hol/src/init/rat.rs
@@ -253,6 +253,197 @@ fn of_nat_via_int_impl() -> Result<Thm> {
     Thm::beta_conv(redex)?.all_intro("n", Type::nat())
 }
 
+// ============================================================================
+// Field operations — defined at the representative level
+// ============================================================================
+//
+// Each op picks a representative pair from its argument(s) via `repPair`,
+// computes on the `int` numerator/denominator components, and re-quotients
+// with `mkRat`. The denominators are kept strictly positive: a product of
+// positives is positive, so `to_pos` re-wraps an `int` denominator into
+// `int.pos` (the *value* is positive; a proof of that positivity is part
+// of the downstream quotient derivations, not needed to build the term).
+
+/// `repPair x ≔ ε(λp. rep x p)` — a representative pair drawn from the
+/// class of the rat term `x`.
+fn rep_pair(x: Term) -> Term {
+    let pair_ty = ip_pair();
+    let rep = Term::spec_rep(rat_spec(), Vec::new());
+    let rep_x = Term::app(rep, x); // (int×int.pos) → bool
+    let p = Term::free("p", pair_ty.clone());
+    let pred = Term::abs(pair_ty.clone(), subst::close(&Term::app(rep_x, p), "p"));
+    Term::app(Term::select_op(pair_ty), pred)
+}
+
+/// `snd p : int.pos` — the denominator of a representative pair as an
+/// `int.pos` (not coerced down to `int`).
+fn den_pos(p: &Term) -> Term {
+    Term::app(snd(Type::int(), int_pos_ty()), p.clone())
+}
+
+/// `abs z : int.pos` — re-wrap an `int` as `int.pos` (used for the
+/// always-positive product denominators).
+fn to_pos(z: Term) -> Term {
+    Term::app(Term::spec_abs(int_pos_spec(), Vec::new()), z)
+}
+
+/// `a + b` on `int`.
+fn iadd(a: Term, b: Term) -> Term {
+    Term::app(Term::app(int::int_add(), a), b)
+}
+
+/// `mkRat (build px py)` for a binary op: `px = repPair x`, `py = repPair y`.
+fn binary_rat(build: impl Fn(&Term, &Term) -> Term) -> Term {
+    let (x, y) = (Term::free("x", rat()), Term::free("y", rat()));
+    let body = mk_rat(&build(&rep_pair(x.clone()), &rep_pair(y.clone())));
+    Term::abs(rat(), subst::close(&Term::abs(rat(), subst::close(&body, "y")), "x"))
+}
+
+/// `0 : rat` ≡ `mkRat (0, 1)`.
+pub fn rat_zero() -> Term {
+    mk_rat(&ip(Term::int_lit(0i128), one_pos()))
+}
+
+/// `1 : rat` ≡ `mkRat (1, 1)`.
+pub fn rat_one() -> Term {
+    mk_rat(&ip(Term::int_lit(1i128), one_pos()))
+}
+
+/// `ratAdd : rat → rat → rat` ≡ `(a/b) + (c/d) = (a·d + c·b)/(b·d)`.
+pub fn rat_add() -> Term {
+    binary_rat(|px, py| {
+        let n = iadd(imul(num(px), den(py)), imul(num(py), den(px)));
+        ip(n, to_pos(imul(den(px), den(py))))
+    })
+}
+
+/// `ratMul : rat → rat → rat` ≡ `(a/b) · (c/d) = (a·c)/(b·d)`.
+pub fn rat_mul() -> Term {
+    binary_rat(|px, py| {
+        ip(imul(num(px), num(py)), to_pos(imul(den(px), den(py))))
+    })
+}
+
+/// `ratNeg : rat → rat` ≡ `-(a/b) = (-a)/b` (denominator unchanged).
+pub fn rat_neg() -> Term {
+    let x = Term::free("x", rat());
+    let px = rep_pair(x.clone());
+    let neg_num = Term::app(int::int_neg(), num(&px));
+    let body = mk_rat(&ip(neg_num, den_pos(&px)));
+    Term::abs(rat(), subst::close(&body, "x"))
+}
+
+// ============================================================================
+// Commutative-ring axioms (and the field inverse) — postulated
+// ============================================================================
+//
+// Same audit-trail style as `init::int`: each is a `Thm::assume` carrying
+// its statement as a self-hyp. They are HOL theorems of the quotient,
+// derivable from the `int` ordered-ring theory; discharging them does not
+// change this public surface. See `SKELETONS.md`.
+
+fn rvar(name: &str) -> Term {
+    Term::free(name, rat())
+}
+fn radd(a: Term, b: Term) -> Term {
+    Term::app(Term::app(rat_add(), a), b)
+}
+fn rmul(a: Term, b: Term) -> Term {
+    Term::app(Term::app(rat_mul(), a), b)
+}
+fn rneg(a: Term) -> Term {
+    Term::app(rat_neg(), a)
+}
+fn forall_rat(vars: &[&str], body: Term) -> Term {
+    let mut t = body;
+    for name in vars.iter().rev() {
+        t = t.forall(name, rat()).expect("forall_rat: bind variable");
+    }
+    t
+}
+
+/// `⊢ ∀a b. a + b = b + a`.
+pub fn add_comm() -> Thm {
+    let (a, b) = (rvar("a"), rvar("b"));
+    let eq = radd(a.clone(), b.clone()).equals(radd(b, a)).expect("add_comm");
+    axiom(forall_rat(&["a", "b"], eq))
+}
+
+/// `⊢ ∀a b c. (a + b) + c = a + (b + c)`.
+pub fn add_assoc() -> Thm {
+    let (a, b, c) = (rvar("a"), rvar("b"), rvar("c"));
+    let lhs = radd(radd(a.clone(), b.clone()), c.clone());
+    let rhs = radd(a, radd(b, c));
+    axiom(forall_rat(&["a", "b", "c"], lhs.equals(rhs).expect("add_assoc")))
+}
+
+/// `⊢ ∀a. a + 0 = a`.
+pub fn add_zero() -> Thm {
+    let a = rvar("a");
+    let eq = radd(a.clone(), rat_zero()).equals(a).expect("add_zero");
+    axiom(forall_rat(&["a"], eq))
+}
+
+/// `⊢ ∀a. a + (-a) = 0` — additive inverse.
+pub fn add_neg() -> Thm {
+    let a = rvar("a");
+    let eq = radd(a.clone(), rneg(a)).equals(rat_zero()).expect("add_neg");
+    axiom(forall_rat(&["a"], eq))
+}
+
+/// `⊢ ∀a b. a * b = b * a`.
+pub fn mul_comm() -> Thm {
+    let (a, b) = (rvar("a"), rvar("b"));
+    let eq = rmul(a.clone(), b.clone()).equals(rmul(b, a)).expect("mul_comm");
+    axiom(forall_rat(&["a", "b"], eq))
+}
+
+/// `⊢ ∀a b c. (a * b) * c = a * (b * c)`.
+pub fn mul_assoc() -> Thm {
+    let (a, b, c) = (rvar("a"), rvar("b"), rvar("c"));
+    let lhs = rmul(rmul(a.clone(), b.clone()), c.clone());
+    let rhs = rmul(a, rmul(b, c));
+    axiom(forall_rat(&["a", "b", "c"], lhs.equals(rhs).expect("mul_assoc")))
+}
+
+/// `⊢ ∀a. a * 1 = a`.
+pub fn mul_one() -> Thm {
+    let a = rvar("a");
+    let eq = rmul(a.clone(), rat_one()).equals(a).expect("mul_one");
+    axiom(forall_rat(&["a"], eq))
+}
+
+/// `⊢ ∀a. a * 0 = 0`.
+pub fn mul_zero() -> Thm {
+    let a = rvar("a");
+    let eq = rmul(a, rat_zero()).equals(rat_zero()).expect("mul_zero");
+    axiom(forall_rat(&["a"], eq))
+}
+
+/// `⊢ ∀a b c. a * (b + c) = a * b + a * c` — left distributivity.
+pub fn distrib() -> Thm {
+    let (a, b, c) = (rvar("a"), rvar("b"), rvar("c"));
+    let lhs = rmul(a.clone(), radd(b.clone(), c.clone()));
+    let rhs = radd(rmul(a.clone(), b), rmul(a, c));
+    axiom(forall_rat(&["a", "b", "c"], lhs.equals(rhs).expect("distrib")))
+}
+
+/// `⊢ ∀a. ¬(a = 0) ⟹ ∃b. a * b = 1` — the field axiom (multiplicative
+/// inverse). This is what makes `rat` a *field* rather than just a ring,
+/// and underwrites division (and so the midpoint form of density).
+pub fn mul_inv() -> Thm {
+    let a = rvar("a");
+    let b = rvar("b");
+    let has_inv = rmul(a.clone(), b)
+        .equals(rat_one())
+        .expect("mul_inv: a * b = 1")
+        .exists("b", rat())
+        .expect("mul_inv: ∃b");
+    let neq = a.clone().equals(rat_zero()).expect("mul_inv: a = 0").not().expect("mul_inv: ≠");
+    let body = neq.imp(has_inv).expect("mul_inv");
+    axiom(forall_rat(&["a"], body))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -344,6 +535,55 @@ mod tests {
     fn maps_have_the_expected_types() {
         assert_eq!(of_int().type_of().unwrap(), Type::fun(Type::int(), rat()));
         assert_eq!(of_nat().type_of().unwrap(), Type::fun(Type::nat(), rat()));
+    }
+
+    #[test]
+    fn operations_have_the_expected_types() {
+        let r = rat();
+        let bin = Type::fun(r.clone(), Type::fun(r.clone(), r.clone()));
+        assert_eq!(rat_add().type_of().unwrap(), bin);
+        assert_eq!(rat_mul().type_of().unwrap(), bin);
+        assert_eq!(rat_neg().type_of().unwrap(), Type::fun(r.clone(), r.clone()));
+        assert_eq!(rat_zero().type_of().unwrap(), r);
+        assert_eq!(rat_one().type_of().unwrap(), rat());
+    }
+
+    #[test]
+    fn ring_axioms_are_well_typed_and_self_flagged() {
+        let all = [
+            add_comm(),
+            add_assoc(),
+            add_zero(),
+            add_neg(),
+            mul_comm(),
+            mul_assoc(),
+            mul_one(),
+            mul_zero(),
+            distrib(),
+            mul_inv(),
+        ];
+        for ax in all {
+            assert!(ax.concl().type_of().unwrap().is_bool());
+            assert!(
+                ax.hyps().iter().any(|h| h == ax.concl()),
+                "a postulated rat axiom carries itself as a hypothesis"
+            );
+        }
+    }
+
+    #[test]
+    fn add_comm_specialises() {
+        // ∀a b. a+b = b+a  ⟹  of_int 1 + of_int 2 = of_int 2 + of_int 1.
+        let one = Term::app(of_int(), Term::int_lit(1i128));
+        let two = Term::app(of_int(), Term::int_lit(2i128));
+        let inst = add_comm()
+            .all_elim(one.clone())
+            .and_then(|t| t.all_elim(two.clone()))
+            .expect("specialise add_comm");
+        let expected = radd(one.clone(), two.clone())
+            .equals(radd(two, one))
+            .unwrap();
+        assert_eq!(inst.concl(), &expected);
     }
 
     #[test]

--- a/crates/covalence-hol/src/init/rat.rs
+++ b/crates/covalence-hol/src/init/rat.rs
@@ -39,7 +39,12 @@
 //!   [`rat_add`], [`rat_neg`], [`rat_mul`]) and the strict order
 //!   ([`rat_lt`]) are defined at the representative level; the ordered-
 //!   field axioms over them are **postulated** (same audit-trail style as
-//!   `init::int`), pending the quotient derivations.
+//!   `init::int`), pending the quotient derivations. On top of those, a
+//!   small `≤` toolkit is **derived**: [`le_refl`], [`lt_imp_le`],
+//!   [`le_trans`], and [`not_one_le_zero`] (from [`le_def`] + the strict
+//!   facts + the one base postulate [`zero_lt_one`]). These are what the
+//!   `real` Dedekind-cut construction in [`init::real`](crate::init::real)
+//!   consumes.
 //! - **Density.** [`dense`] — `∀x y. x < y ⟹ ∃z. x < z ∧ z < y` — is
 //!   **derived** from the two mediant-inequality postulates via the
 //!   mediant `(a+c)/(b+d)`, the witness that needs no division.
@@ -47,7 +52,7 @@
 use covalence_core::defs::{fst, int_pos_spec, int_pos_ty, prod, snd};
 use covalence_core::{Result, Term, Thm, Type, subst};
 
-use crate::init::ext::TermExt;
+use crate::init::ext::{TermExt, ThmExt};
 use crate::init::{int, logic, nat};
 
 // Re-export the `defs/rat.rs` catalogue (the type handles + the declared
@@ -511,6 +516,186 @@ pub fn le_def() -> Thm {
 }
 
 // ============================================================================
+// Order toolkit — derived `≤` facts (and the one base strictness postulate)
+// ============================================================================
+//
+// `le_refl` / `lt_imp_le` / `le_trans` are **derived** from `le_def` and the
+// strict-order postulates (`lt_irrefl` / `lt_trans`). The single new
+// postulate is `zero_lt_one` (`0 < 1`) — the base strictness fact reduction
+// cannot reach (`ratLt` picks representatives via ε). `not_one_le_zero`
+// (`¬(1 ≤ 0)`) then follows. These are what the `real` Dedekind-cut proofs
+// (`init::real`) consume: cut upward-closure is `le_trans`, non-emptiness is
+// `le_refl`, and `0 ≠ 1` for reals turns on `not_one_le_zero`.
+
+/// `⊢ 0 < 1` — the base strictness fact (postulated; `ratLt` is stuck at
+/// the ε-chosen representatives, so this is not reducible).
+pub fn zero_lt_one() -> Thm {
+    axiom(rlt(rat_zero(), rat_one()))
+}
+
+cached_thm! {
+    /// `⊢ ∀a. a ≤ a` — reflexivity of `≤`, from `le_def` + `=`-reflexivity.
+    pub fn le_refl() -> Thm {
+        le_refl_impl().expect("le_refl")
+    }
+}
+fn le_refl_impl() -> Result<Thm> {
+    let a = rvar("a");
+    let ld = le_def().all_elim(a.clone())?.all_elim(a.clone())?; // (a≤a) = (a<a ∨ a=a)
+    let disj = Thm::refl(a.clone())?.or_intro_r(rlt(a.clone(), a.clone()))?; // ⊢ a<a ∨ a=a
+    ld.sym()?.eq_mp(disj)?.all_intro("a", rat())
+}
+
+cached_thm! {
+    /// `⊢ ∀a b. a < b ⟹ a ≤ b` — strict implies non-strict.
+    pub fn lt_imp_le() -> Thm {
+        lt_imp_le_impl().expect("lt_imp_le")
+    }
+}
+fn lt_imp_le_impl() -> Result<Thm> {
+    let (a, b) = (rvar("a"), rvar("b"));
+    let lt = rlt(a.clone(), b.clone());
+    let ld = le_def().all_elim(a.clone())?.all_elim(b.clone())?; // (a≤b)=(a<b ∨ a=b)
+    let disj = Thm::assume(lt.clone())?
+        .or_intro_l(a.clone().equals(b.clone())?)?; // {a<b} ⊢ a<b ∨ a=b
+    ld.sym()?
+        .eq_mp(disj)?
+        .imp_intro(&lt)?
+        .all_intro("b", rat())?
+        .all_intro("a", rat())
+}
+
+cached_thm! {
+    /// `⊢ ∀a b c. a ≤ b ⟹ b ≤ c ⟹ a ≤ c` — transitivity of `≤`, by case
+    /// analysis on `le_def` (each `≤` is `<` or `=`) using `lt_trans` and
+    /// equality congruence.
+    pub fn le_trans() -> Thm {
+        le_trans_impl().expect("le_trans")
+    }
+}
+fn le_trans_impl() -> Result<Thm> {
+    let (a, b, c) = (rvar("a"), rvar("b"), rvar("c"));
+    let (hab, hbc) = (rle(a.clone(), b.clone()), rle(b.clone(), c.clone()));
+
+    // Goal disjunction `a<c ∨ a=c`, and the closer `(a<c ∨ a=c) ⟹ a≤c`.
+    let ld_ac = le_def().all_elim(a.clone())?.all_elim(c.clone())?; // (a≤c)=(a<c ∨ a=c)
+    let close_goal = |disj: Thm| -> Result<Thm> { ld_ac.clone().sym()?.eq_mp(disj) };
+
+    // From the two `≤` hyps, the two disjunctions.
+    let d_ab = le_def()
+        .all_elim(a.clone())?
+        .all_elim(b.clone())?
+        .eq_mp(Thm::assume(hab.clone())?)?; // {a≤b} ⊢ a<b ∨ a=b
+    let d_bc = le_def()
+        .all_elim(b.clone())?
+        .all_elim(c.clone())?
+        .eq_mp(Thm::assume(hbc.clone())?)?; // {b≤c} ⊢ b<c ∨ b=c
+
+    // The four leaf derivations of `a≤c`, each as `<branch hyp> ⊢ a≤c`.
+    // a<b, b<c ⟹ a<c.
+    let lt_lt = |ab: Thm, bc: Thm| -> Result<Thm> {
+        let ac = lt_trans()
+            .all_elim(a.clone())?
+            .all_elim(b.clone())?
+            .all_elim(c.clone())?
+            .imp_elim(ab)?
+            .imp_elim(bc)?; // a<c
+        close_goal(ac.or_intro_l(a.clone().equals(c.clone())?)?)
+    };
+    // a<b, b=c ⟹ a<c   (rewrite the `b` in `a<b` to `c`).
+    let lt_eq = |ab: Thm, bc_eq: Thm| -> Result<Thm> {
+        let cong = bc_eq.cong_arg(Term::app(rat_lt(), a.clone()))?; // (a<b)=(a<c)
+        let ac = cong.eq_mp(ab)?; // a<c
+        close_goal(ac.or_intro_l(a.clone().equals(c.clone())?)?)
+    };
+    // a=b, b<c ⟹ a<c   (rewrite the `b` in `b<c` to `a`).
+    let eq_lt = |ab_eq: Thm, bc: Thm| -> Result<Thm> {
+        let cong = ab_eq.cong_arg(rat_lt())?.cong_fn(c.clone())?; // (a<c)=(b<c)
+        let ac = cong.sym()?.eq_mp(bc)?; // a<c
+        close_goal(ac.or_intro_l(a.clone().equals(c.clone())?)?)
+    };
+    // a=b, b=c ⟹ a=c.
+    let eq_eq = |ab_eq: Thm, bc_eq: Thm| -> Result<Thm> {
+        let ac = ab_eq.trans(bc_eq)?; // a=c
+        close_goal(ac.or_intro_r(rlt(a.clone(), c.clone()))?)
+    };
+
+    // Inner case split on `b<c ∨ b=c`, given a fixed left branch builder.
+    let ab_lt = rlt(a.clone(), b.clone());
+    let ab_eq = a.clone().equals(b.clone())?;
+    let bc_lt = rlt(b.clone(), c.clone());
+    let bc_eq = b.clone().equals(c.clone())?;
+
+    // Left of the outer split: assume a<b, case-split d_bc.
+    let outer_left = {
+        let ab = Thm::assume(ab_lt.clone())?;
+        let br_lt = lt_lt(ab.clone(), Thm::assume(bc_lt.clone())?)?.imp_intro(&bc_lt)?;
+        let br_eq = lt_eq(ab, Thm::assume(bc_eq.clone())?)?.imp_intro(&bc_eq)?;
+        d_bc.clone().or_elim(br_lt, br_eq)?.imp_intro(&ab_lt)? // {a≤b,b≤c} ⊢ a<b ⟹ a≤c
+    };
+    // Right of the outer split: assume a=b, case-split d_bc.
+    let outer_right = {
+        let ab = Thm::assume(ab_eq.clone())?;
+        let br_lt = eq_lt(ab.clone(), Thm::assume(bc_lt.clone())?)?.imp_intro(&bc_lt)?;
+        let br_eq = eq_eq(ab, Thm::assume(bc_eq.clone())?)?.imp_intro(&bc_eq)?;
+        d_bc.or_elim(br_lt, br_eq)?.imp_intro(&ab_eq)? // {a≤b,b≤c} ⊢ a=b ⟹ a≤c
+    };
+
+    d_ab.or_elim(outer_left, outer_right)? // {a≤b,b≤c} ⊢ a≤c
+        .imp_intro(&hbc)?
+        .imp_intro(&hab)?
+        .all_intro("c", rat())?
+        .all_intro("b", rat())?
+        .all_intro("a", rat())
+}
+
+cached_thm! {
+    /// `⊢ ¬(1 ≤ 0)` — from `0 < 1` (`zero_lt_one`), `lt_trans` and
+    /// `lt_irrefl`. The distinguishing fact behind `real` `0 ≠ 1`.
+    pub fn not_one_le_zero() -> Thm {
+        not_one_le_zero_impl().expect("not_one_le_zero")
+    }
+}
+fn not_one_le_zero_impl() -> Result<Thm> {
+    let (zero, one) = (rat_zero(), rat_one());
+    let one_le_zero = rle(one.clone(), zero.clone());
+    // (1≤0) = (1<0 ∨ 1=0); under the assumption, the disjunction.
+    let ld = le_def().all_elim(one.clone())?.all_elim(zero.clone())?;
+    let disj = ld.eq_mp(Thm::assume(one_le_zero.clone())?)?; // {1≤0} ⊢ 1<0 ∨ 1=0
+
+    let lt_10 = rlt(one.clone(), zero.clone());
+    let eq_10 = one.clone().equals(zero.clone())?;
+
+    // 1<0 branch: 0<1 and 1<0 give 0<0, contradicting irreflexivity.
+    let br_lt = {
+        let chain = lt_trans()
+            .all_elim(zero.clone())?
+            .all_elim(one.clone())?
+            .all_elim(zero.clone())?
+            .imp_elim(zero_lt_one())?
+            .imp_elim(Thm::assume(lt_10.clone())?)?; // 0<0
+        lt_irrefl()
+            .all_elim(zero.clone())?
+            .not_elim(chain)?
+            .imp_intro(&lt_10)?
+    };
+    // 1=0 branch: rewrite 0<1 by 1=0 to 0<0, same contradiction.
+    let br_eq = {
+        let cong = Thm::assume(eq_10.clone())?.cong_arg(Term::app(rat_lt(), zero.clone()))?; // (0<1)=(0<0)
+        let zero_lt_zero = cong.eq_mp(zero_lt_one())?; // 0<0
+        lt_irrefl()
+            .all_elim(zero.clone())?
+            .not_elim(zero_lt_zero)?
+            .imp_intro(&eq_10)?
+    };
+
+    disj
+        .or_elim(br_lt, br_eq)? // {1≤0, 0<1} ⊢ F
+        .imp_intro(&one_le_zero)?
+        .not_intro()
+}
+
+// ============================================================================
 // Density — DERIVED from the two mediant inequalities
 // ============================================================================
 //
@@ -744,6 +929,33 @@ mod tests {
             assert!(ax.concl().type_of().unwrap().is_bool());
             assert!(ax.hyps().iter().any(|h| h == ax.concl()));
         }
+    }
+
+    #[test]
+    fn order_toolkit_derivations_are_well_typed() {
+        // le_refl / lt_imp_le / le_trans / not_one_le_zero are derived: they
+        // carry only postulate hypotheses (no stray assumptions), are
+        // bool-typed, and have the expected shapes.
+        let a = rvar("a");
+        let refl = le_refl().all_elim(a.clone()).unwrap();
+        assert_eq!(refl.concl(), &rle(a.clone(), a.clone()));
+
+        // not_one_le_zero : ¬(1 ≤ 0), resting on the zero_lt_one postulate.
+        let n = not_one_le_zero();
+        assert_eq!(n.concl(), &rle(rat_one(), rat_zero()).not().unwrap());
+        assert!(n.hyps().iter().all(|h| h.type_of().unwrap().is_bool()));
+
+        // le_trans specialises to a concrete double implication.
+        let (x, y, z) = (rvar("x"), rvar("y"), rvar("z"));
+        let lt = le_trans()
+            .all_elim(x.clone())
+            .and_then(|t| t.all_elim(y.clone()))
+            .and_then(|t| t.all_elim(z.clone()))
+            .unwrap();
+        let expected = rle(x.clone(), y.clone())
+            .imp(rle(y, z.clone()).imp(rle(x, z)).unwrap())
+            .unwrap();
+        assert_eq!(lt.concl(), &expected);
     }
 
     #[test]

--- a/crates/covalence-hol/src/init/real.rs
+++ b/crates/covalence-hol/src/init/real.rs
@@ -1,0 +1,524 @@
+//! `real` theorems: the Dedekind-cut construction of the reals, built on
+//! [`init::rat`](crate::init::rat).
+//!
+//! ## The construction
+//!
+//! `real := close rat ratLe` ([`defs/real.rs`](covalence_core::defs)) is
+//! the type of **upper Dedekind cuts**: a real is a non-empty subset of
+//! `rat` that is upward-closed under `≤`. The carrier of the subtype is
+//! the powerset `rat → bool`, and the selector predicate (the `close`
+//! predicate, [`cut_pred`]) is
+//!
+//! ```text
+//!     λS. (∀x y. ratLe x y ⟹ S x ⟹ S y) ∧ (∃x. S x)
+//! ```
+//!
+//! — "`S` is upward-closed under `≤` and non-empty". We bridge a real and
+//! its cut-set with the kernel subtype coercions: [`mk_real`] (`abs`)
+//! wraps a cut-set into a real and [`cut_of`] (`rep`) recovers it.
+//!
+//! The **principal cut** of a rational `q` is its up-set `{x | q ≤ x}`,
+//! written η-cleanly as the partial application `ratLe q : rat → bool`
+//! (so `(ratLe q) x` is `ratLe q x` with no stray β-redex). [`of_rat`]
+//! embeds `rat` into `real` this way; [`real_zero`] / [`real_one`] are the
+//! principal cuts of `0` / `1`.
+//!
+//! ## Status
+//!
+//! - **Scaffolding** (this layer): the coercions, [`of_rat`], the order
+//!   [`real_le`] (reverse inclusion of cut-sets), and [`real_zero`] /
+//!   [`real_one`].
+//! - **`is_cut`** — `⊢ cut_pred (ratLe q)`, that every principal up-set is
+//!   a genuine cut — is **proved** from the `rat` `≤` toolkit
+//!   (`le_trans` for upward closure, `le_refl` for non-emptiness).
+//! - **[`zero_ne_one`]** — `⊢ ¬(0 = 1)` — is **proved**: distinct
+//!   principal cuts (the rational `0` lies in `ratLe 0` but not `ratLe 1`,
+//!   by `not_one_le_zero`), transported through the subtype `rep`/`abs`.
+//! - **[`complete`]** — the least-upper-bound property — is **derived**
+//!   from the supremum-cut postulates ([`sup_is_ub`], [`sup_is_least`]),
+//!   exactly as `rat::dense` is derived from the mediant postulates: the
+//!   supremum is the *intersection of the cut-sets* ([`real_sup`]).
+
+use covalence_core::defs::{real_spec, real_ty};
+use covalence_core::{Result, Term, Thm, Type, subst};
+
+use crate::init::ext::{TermExt, ThmExt};
+use crate::init::{logic, rat};
+
+// Re-export the `defs/real.rs` catalogue.
+pub use covalence_core::defs::real_ty as real_type;
+
+// ============================================================================
+// Coercions and small term helpers
+// ============================================================================
+
+/// `real` — the reals type.
+fn real() -> Type {
+    real_ty()
+}
+
+/// `rat` — the base type of the cuts.
+fn ratt() -> Type {
+    rat::rat_ty()
+}
+
+/// `abs : (rat→bool) → real` — wrap a cut-set into a real.
+fn real_abs() -> Term {
+    Term::spec_abs(real_spec(), Vec::new())
+}
+/// `rep : real → (rat→bool)` — the cut-set of a real.
+fn real_rep() -> Term {
+    Term::spec_rep(real_spec(), Vec::new())
+}
+
+/// `mkReal S ≔ abs S` — the real whose cut-set is `S : rat→bool`.
+fn mk_real(s: Term) -> Term {
+    Term::app(real_abs(), s)
+}
+/// `cutOf r ≔ rep r : rat→bool` — the cut-set of the real `r`.
+fn cut_of(r: Term) -> Term {
+    Term::app(real_rep(), r)
+}
+
+/// The `close`/cut selector predicate `P : (rat→bool) → bool` — the
+/// `real` subtype's `tm()`.
+fn cut_pred() -> Term {
+    real_spec()
+        .tm()
+        .expect("real is a close-subtype with a selector predicate")
+        .clone()
+}
+
+/// `ratLe q : rat → bool` — the principal upper cut `{x | q ≤ x}` of a
+/// rational `q`, η-cleanly as a partial application.
+fn upper_cut(q: Term) -> Term {
+    Term::app(rat::rat_le(), q)
+}
+
+// ============================================================================
+// Embedding ℚ ↪ ℝ and the order
+// ============================================================================
+
+/// `of_rat : rat → real` ≡ `λq. mkReal (ratLe q)` — the principal-cut
+/// embedding of the rationals.
+pub fn of_rat() -> Term {
+    let q = Term::free("q", ratt());
+    let body = mk_real(upper_cut(q.clone()));
+    Term::abs(ratt(), subst::close(&body, "q"))
+}
+
+/// `0 : real` ≡ the principal cut of `rat`'s `0`.
+pub fn real_zero() -> Term {
+    mk_real(upper_cut(rat::rat_zero()))
+}
+
+/// `1 : real` ≡ the principal cut of `rat`'s `1`.
+pub fn real_one() -> Term {
+    mk_real(upper_cut(rat::rat_one()))
+}
+
+/// `realLe : real → real → bool` ≡ `λr s. ∀q. cutOf s q ⟹ cutOf r q` —
+/// the order on reals as **reverse inclusion** of cut-sets (a larger real
+/// has a smaller up-set).
+pub fn real_le() -> Term {
+    let (r, s) = (Term::free("r", real()), Term::free("s", real()));
+    let q = Term::free("q", ratt());
+    let body = Term::app(cut_of(s.clone()), q.clone())
+        .imp(Term::app(cut_of(r.clone()), q))
+        .expect("real_le: body")
+        .forall("q", ratt())
+        .expect("real_le: ∀q");
+    Term::abs(
+        real(),
+        subst::close(&Term::abs(real(), subst::close(&body, "s")), "r"),
+    )
+}
+
+/// `r ≤ s` on `real`.
+fn rle(r: Term, s: Term) -> Term {
+    Term::app(Term::app(real_le(), r), s)
+}
+
+/// `ratLe a b` — a rational `≤` atom.
+fn rat_le_app(a: &Term, b: &Term) -> Term {
+    Term::app(Term::app(rat::rat_le(), a.clone()), b.clone())
+}
+
+// ============================================================================
+// Principal up-sets are genuine cuts
+// ============================================================================
+
+/// `⊢ cut_pred (ratLe q)` — every principal up-set `{x | q ≤ x}` is a
+/// Dedekind cut. **Proved** from the `rat` `≤` toolkit: upward closure is
+/// `le_trans` (`q ≤ x` and `x ≤ y` give `q ≤ y`), non-emptiness is
+/// `le_refl` (the witness `q` lies in its own up-set).
+///
+/// The conclusion is the *un-reduced* redex `cut_pred (ratLe q)` — exactly
+/// the antecedent [`Thm::spec_rep_abs_fwd`] expects — obtained by proving
+/// the β-reduced conjunction and transporting back across `beta_conv`.
+fn is_cut(q: &Term) -> Result<Thm> {
+    let s = upper_cut(q.clone()); // ratLe q : rat→bool
+    let pred_app = Term::app(cut_pred(), s);
+    let conv = Thm::beta_conv(pred_app)?; // ⊢ pred_app = (closed ∧ nonempty)
+    let clean = conv.concl().as_eq().expect("beta_conv yields an equation").1.clone();
+
+    // clean = and closed nonempty = App(App(and, closed), nonempty).
+    let (and_closed, nonempty_t) = clean.as_app().expect("clean is a conjunction");
+    let closed_t = and_closed.as_app().expect("clean is a conjunction").1.clone();
+    let nonempty_t = nonempty_t.clone();
+
+    // closed: ∀x y. x≤y ⟹ q≤x ⟹ q≤y, via le_trans q x y (antecedents reordered).
+    let closed_thm = {
+        let (x, y) = (Term::free("x", ratt()), Term::free("y", ratt()));
+        let xy = rat_le_app(&x, &y);
+        let qx = rat_le_app(q, &x);
+        let qy = rat::le_trans()
+            .all_elim(q.clone())?
+            .all_elim(x.clone())?
+            .all_elim(y.clone())?
+            .imp_elim(Thm::assume(qx.clone())?)?
+            .imp_elim(Thm::assume(xy.clone())?)?; // {q≤x, x≤y} ⊢ q≤y
+        qy.imp_intro(&qx)?
+            .imp_intro(&xy)?
+            .all_intro("y", ratt())?
+            .all_intro("x", ratt())?
+    };
+
+    // nonempty: ∃x. q≤x, witness q, proof le_refl q (β-expanded to `pred q`).
+    let nonempty_thm = {
+        let pred = nonempty_t.as_app().expect("nonempty is `exists pred`").1.clone();
+        let refl = rat::le_refl().all_elim(q.clone())?; // ⊢ q≤q
+        let pf = Thm::beta_conv(Term::app(pred.clone(), q.clone()))?
+            .sym()?
+            .eq_mp(refl)?; // ⊢ pred q
+        logic::exists_intro(pred, q.clone(), pf)? // ⊢ ∃x. q≤x
+    };
+
+    // Re-assemble the conjunction and transport back to the redex.
+    debug_assert_eq!(closed_thm.concl(), &closed_t);
+    let p_clean = closed_thm.and_intro(nonempty_thm)?; // ⊢ closed ∧ nonempty
+    conv.sym()?.eq_mp(p_clean) // ⊢ cut_pred (ratLe q)
+}
+
+// ============================================================================
+// 0 ≠ 1
+// ============================================================================
+
+cached_thm! {
+    /// `⊢ ¬(0 = 1)` — zero and one are distinct reals.
+    ///
+    /// **Proved.** The principal cuts `ratLe 0` and `ratLe 1` differ at the
+    /// rational `0`: `0 ≤ 0` holds (`le_refl`) but `1 ≤ 0` does not
+    /// (`not_one_le_zero`). Assuming `0 = 1`, congruence under `rep` plus
+    /// the subtype round-trip [`Thm::spec_rep_abs_fwd`] (discharged by
+    /// [`is_cut`]) collapses the two cut-sets, so `0 ≤ 0 = 1 ≤ 0`,
+    /// contradicting `not_one_le_zero`. Genuine *modulo* the `rat` order
+    /// postulates `is_cut` / `not_one_le_zero` rest on.
+    pub fn zero_ne_one() -> Thm {
+        zero_ne_one_impl().expect("real zero_ne_one")
+    }
+}
+fn zero_ne_one_impl() -> Result<Thm> {
+    let (zero, one) = (rat::rat_zero(), rat::rat_one());
+    let (s0, s1) = (upper_cut(zero.clone()), upper_cut(one.clone()));
+    let eq01 = real_zero().equals(real_one())?; // abs s0 = abs s1
+
+    // rep both sides of the assumed equality.
+    let reps_eq = Thm::assume(eq01.clone())?.cong_arg(real_rep())?; // {eq} ⊢ rep(abs s0)=rep(abs s1)
+    // rep(abs sᵢ) = sᵢ, the subtype round-trip discharged by `is_cut`.
+    let r0 = Thm::spec_rep_abs_fwd(real_spec(), Vec::new(), s0)?.imp_elim(is_cut(&zero)?)?;
+    let r1 = Thm::spec_rep_abs_fwd(real_spec(), Vec::new(), s1)?.imp_elim(is_cut(&one)?)?;
+    let sets_eq = r0.sym()?.trans(reps_eq)?.trans(r1)?; // {eq} ⊢ s0 = s1
+
+    // Evaluate both cut-sets at the rational 0: (0≤0) = (1≤0).
+    let at0 = sets_eq.cong_fn(zero.clone())?; // {eq} ⊢ ratLe 0 0 = ratLe 1 0
+    let le00 = rat::le_refl().all_elim(zero.clone())?; // ⊢ ratLe 0 0
+    let le10 = at0.eq_mp(le00)?; // {eq} ⊢ ratLe 1 0
+
+    // ¬(1≤0) gives the contradiction.
+    rat::not_one_le_zero()
+        .not_elim(le10)? // {eq, …} ⊢ F
+        .imp_intro(&eq01)?
+        .not_intro() // ⊢ ¬(0 = 1)
+}
+
+// ============================================================================
+// Completeness — the least-upper-bound property
+// ============================================================================
+//
+// Derived from the supremum-cut postulates exactly as `rat::dense` is
+// derived from the mediant postulates: the least upper bound of a set `A`
+// of reals is the **intersection of their cut-sets**, `real_sup A`, and the
+// two postulated leaves assert that this intersection *is* an upper bound
+// and *is* the least one. Both unfold to set/order facts about the cuts,
+// blocked on the same `rat`/order theory the rest of the tower waits on
+// (`SKELETONS.md`); `complete` itself is a genuine derivation from them.
+
+/// Postulate a `real` axiom: `{t} ⊢ t` (self-flagged audit trail, as in
+/// `init::int` / `init::rat`).
+fn axiom(t: Term) -> Thm {
+    Thm::assume(t).expect("init::real::axiom: term must be bool-typed")
+}
+
+/// `real → bool` — a set of reals.
+fn real_set() -> Type {
+    Type::fun(real(), Type::bool())
+}
+
+/// `is_ub A u ≔ ∀a. A a ⟹ a ≤ u` — `u` is an upper bound of `A`.
+fn is_ub(a_set: &Term, u: &Term) -> Term {
+    let a = Term::free("a", real());
+    Term::app(a_set.clone(), a.clone())
+        .imp(rle(a, u.clone()))
+        .expect("is_ub: body")
+        .forall("a", real())
+        .expect("is_ub: ∀a")
+}
+
+/// `is_lub A s ≔ is_ub A s ∧ (∀u. is_ub A u ⟹ s ≤ u)` — `s` is the least
+/// upper bound of `A`.
+fn is_lub(a_set: &Term, s: &Term) -> Term {
+    let u = Term::free("u", real());
+    let least = is_ub(a_set, &u)
+        .imp(rle(s.clone(), u))
+        .expect("is_lub: least body")
+        .forall("u", real())
+        .expect("is_lub: ∀u");
+    is_ub(a_set, s).and(least).expect("is_lub: conjunction")
+}
+
+/// `nonempty A ≔ ∃a. A a`.
+fn nonempty(a_set: &Term) -> Term {
+    let a = Term::free("a", real());
+    Term::app(a_set.clone(), a)
+        .exists("a", real())
+        .expect("nonempty: ∃a")
+}
+
+/// `bounded A ≔ ∃u. is_ub A u` — `A` is bounded above.
+fn bounded(a_set: &Term) -> Term {
+    let u = Term::free("u", real());
+    is_ub(a_set, &u).exists("u", real()).expect("bounded: ∃u")
+}
+
+/// `realSup : (real→bool) → real` ≡ `λA. mkReal (λq. ∀a. A a ⟹ cutOf a q)`
+/// — the supremum as the **intersection of the cut-sets** of the members
+/// of `A` (for upper cuts, sup = intersection).
+pub fn real_sup() -> Term {
+    let a_set = Term::free("A", real_set());
+    let q = Term::free("q", ratt());
+    let a = Term::free("a", real());
+    let inner = Term::app(a_set.clone(), a.clone())
+        .imp(Term::app(cut_of(a), q.clone()))
+        .expect("real_sup: ∀a body")
+        .forall("a", real())
+        .expect("real_sup: ∀a");
+    let cutset = Term::abs(ratt(), subst::close(&inner, "q")); // λq. ∀a. A a ⟹ rep a q
+    let body = mk_real(cutset);
+    Term::abs(real_set(), subst::close(&body, "A"))
+}
+/// `realSup A` applied.
+fn sup(a_set: &Term) -> Term {
+    Term::app(real_sup(), a_set.clone())
+}
+
+/// `⊢ ∀A. nonempty A ⟹ bounded A ⟹ is_ub A (realSup A)` — the supremum
+/// cut is an upper bound. **Postulated** (audit hyp); unfolds to "a
+/// rational in every member-cut is `≥` every member" — a set/order fact
+/// about the cuts (`SKELETONS.md`).
+pub fn sup_is_ub() -> Thm {
+    let a_set = Term::free("A", real_set());
+    let concl = is_ub(&a_set, &sup(&a_set));
+    let body = nonempty(&a_set)
+        .imp(bounded(&a_set).imp(concl).expect("sup_is_ub inner"))
+        .expect("sup_is_ub");
+    axiom(body.forall("A", real_set()).expect("sup_is_ub: ∀A"))
+}
+
+/// `⊢ ∀A. nonempty A ⟹ bounded A ⟹ ∀u. is_ub A u ⟹ realSup A ≤ u` — the
+/// supremum cut is the *least* upper bound. **Postulated** (audit hyp);
+/// unfolds to "the intersection-cut contains every upper-bound cut" — the
+/// dual set/order fact (`SKELETONS.md`).
+pub fn sup_is_least() -> Thm {
+    let a_set = Term::free("A", real_set());
+    let u = Term::free("u", real());
+    let inner = is_ub(&a_set, &u)
+        .imp(rle(sup(&a_set), u))
+        .expect("sup_is_least: u body")
+        .forall("u", real())
+        .expect("sup_is_least: ∀u");
+    let body = nonempty(&a_set)
+        .imp(bounded(&a_set).imp(inner).expect("sup_is_least inner"))
+        .expect("sup_is_least");
+    axiom(body.forall("A", real_set()).expect("sup_is_least: ∀A"))
+}
+
+cached_thm! {
+    /// `⊢ ∀A. nonempty A ⟹ bounded A ⟹ ∃s. is_lub A s` — **the reals are
+    /// complete** (the least-upper-bound property).
+    ///
+    /// A genuine derivation: the witness is the supremum cut [`real_sup`]
+    /// `A` (the intersection of the members' cut-sets); [`sup_is_ub`] and
+    /// [`sup_is_least`] are its two least-upper-bound properties, packaged
+    /// by `∧`- and `∃`-introduction. The only postulated leaves are those
+    /// two; discharging them makes this hypothesis-free. (Same shape as
+    /// `rat::dense` over its mediant postulates.)
+    pub fn complete() -> Thm {
+        complete_impl().expect("completeness derivation")
+    }
+}
+fn complete_impl() -> Result<Thm> {
+    let a_set = Term::free("A", real_set());
+    let (ne, bd) = (nonempty(&a_set), bounded(&a_set));
+    let s = sup(&a_set);
+
+    // {ne, bd} ⊢ is_ub A s   and   {ne, bd} ⊢ ∀u. is_ub A u ⟹ s ≤ u.
+    let ub = sup_is_ub()
+        .all_elim(a_set.clone())?
+        .imp_elim(Thm::assume(ne.clone())?)?
+        .imp_elim(Thm::assume(bd.clone())?)?;
+    let least = sup_is_least()
+        .all_elim(a_set.clone())?
+        .imp_elim(Thm::assume(ne.clone())?)?
+        .imp_elim(Thm::assume(bd.clone())?)?;
+    let lub = ub.and_intro(least)?; // {ne, bd} ⊢ is_lub A s
+
+    // ∃s. is_lub A s, with witness the supremum cut.
+    let s_var = Term::free("s", real());
+    let pred = Term::abs(real(), subst::close(&is_lub(&a_set, &s_var), "s"));
+    let pf = Thm::beta_conv(Term::app(pred.clone(), s.clone()))?
+        .sym()?
+        .eq_mp(lub)?; // {ne, bd} ⊢ pred s
+    let ex = logic::exists_intro(pred, s, pf)?; // {ne, bd} ⊢ ∃s. is_lub A s
+
+    ex.imp_intro(&bd)?
+        .imp_intro(&ne)?
+        .all_intro("A", real_set())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `rat → bool` — the powerset carrier a cut-set lives in.
+    fn powerset() -> Type {
+        Type::fun(ratt(), Type::bool())
+    }
+
+    #[test]
+    fn real_ty_matches_the_catalogue() {
+        assert_eq!(real(), covalence_core::defs::real_ty());
+        assert!(!real().is_bool());
+    }
+
+    #[test]
+    fn carrier_is_the_rational_powerset() {
+        // abs : (rat→bool) → real ; rep : real → (rat→bool).
+        assert_eq!(
+            real_abs().type_of().unwrap(),
+            Type::fun(powerset(), real())
+        );
+        assert_eq!(
+            real_rep().type_of().unwrap(),
+            Type::fun(real(), powerset())
+        );
+    }
+
+    #[test]
+    fn embedding_and_constants_have_expected_types() {
+        assert_eq!(of_rat().type_of().unwrap(), Type::fun(ratt(), real()));
+        assert_eq!(real_zero().type_of().unwrap(), real());
+        assert_eq!(real_one().type_of().unwrap(), real());
+    }
+
+    #[test]
+    fn real_le_is_a_binary_relation() {
+        assert_eq!(
+            real_le().type_of().unwrap(),
+            Type::fun(real(), Type::fun(real(), Type::bool()))
+        );
+        // `r ≤ s` is a bool.
+        let (r, s) = (Term::free("r", real()), Term::free("s", real()));
+        assert!(rle(r, s).type_of().unwrap().is_bool());
+    }
+
+    #[test]
+    fn is_cut_proves_a_principal_up_set_is_a_cut() {
+        // A concrete rational (`is_cut` is only ever called on closed
+        // rationals; `exists_intro` reserves the name `q` internally).
+        let q = rat::rat_zero();
+        let thm = is_cut(&q).expect("is_cut q");
+        // Conclusion is exactly the redex `cut_pred (ratLe q)`.
+        assert_eq!(thm.concl(), &Term::app(cut_pred(), upper_cut(q)));
+        assert!(thm.concl().type_of().unwrap().is_bool());
+    }
+
+    #[test]
+    fn zero_is_distinct_from_one() {
+        let thm = zero_ne_one();
+        // Statement: ¬(0 = 1).
+        assert_eq!(
+            thm.concl(),
+            &real_zero().equals(real_one()).unwrap().not().unwrap()
+        );
+        // Genuine modulo the rat-order postulates: the assumed `0 = 1` is
+        // discharged, so no equation hypothesis remains — only bool
+        // (postulate) hyps.
+        let eq01 = real_zero().equals(real_one()).unwrap();
+        assert!(
+            !thm.hyps().iter().any(|h| h == &eq01),
+            "the assumed equality is discharged"
+        );
+        for h in thm.hyps() {
+            assert!(h.type_of().unwrap().is_bool());
+        }
+    }
+
+    #[test]
+    fn sup_postulates_and_completeness_are_well_formed() {
+        // real_sup : (real→bool) → real.
+        assert_eq!(
+            real_sup().type_of().unwrap(),
+            Type::fun(real_set(), real())
+        );
+        // The two sup postulates are self-flagged bool statements.
+        for ax in [sup_is_ub(), sup_is_least()] {
+            assert!(ax.concl().type_of().unwrap().is_bool());
+            assert!(ax.hyps().iter().any(|h| h == ax.concl()));
+        }
+    }
+
+    #[test]
+    fn completeness_is_derived_from_the_sup_postulates() {
+        let thm = complete();
+        // Shape: ∀A. nonempty A ⟹ bounded A ⟹ ∃s. is_lub A s. Specialise A.
+        let a_set = Term::free("A", real_set());
+        let inst = thm.clone().all_elim(a_set.clone()).unwrap();
+        let s = Term::free("s", real());
+        let pred = Term::abs(real(), subst::close(&is_lub(&a_set, &s), "s"));
+        let exists_lub = Term::app(covalence_core::defs::exists(real()), pred);
+        let expected = nonempty(&a_set)
+            .imp(bounded(&a_set).imp(exists_lub).unwrap())
+            .unwrap();
+        assert_eq!(inst.concl(), &expected);
+
+        // Genuine modulo exactly the two sup postulates: those are the only
+        // hypotheses (each a bool statement).
+        assert_eq!(thm.hyps().len(), 2, "only the two sup postulates remain");
+        for h in thm.hyps() {
+            assert!(h.type_of().unwrap().is_bool());
+        }
+    }
+
+    #[test]
+    fn cut_pred_is_the_close_predicate() {
+        // cut_pred : (rat→bool) → bool.
+        assert_eq!(
+            cut_pred().type_of().unwrap(),
+            Type::fun(powerset(), Type::bool())
+        );
+        // It applies to a principal cut to give a bool statement.
+        let p = Term::app(cut_pred(), upper_cut(rat::rat_zero()));
+        assert!(p.type_of().unwrap().is_bool());
+    }
+}


### PR DESCRIPTION
Add `init::rat`, re-exporting the `defs/rat.rs` catalogue (`rat_spec`,
`rat_ty`, `rat_le`) and building the quotient scaffolding for
`rat := (int × int.pos) / ~`:

- `rat_rel` — the cross-multiplication relation `(a,b) ~ (c,d) ⟺ a·d = c·b`,
  structurally the term `defs/rat.rs` quotients by;
- `num` / `den` representative-pair accessors (denominator coerced from
  `int.pos` via the spec `rep`);
- `mk_rat` — the class constructor over the generic `quotient::mk_class`.

Mirrors `init::int`'s Grothendieck scaffolding one level up.
https://claude.ai/code/session_01UwvCd5rTiCBt7fsAAw2c9U