### PR TITLE
covalence-hol/init/real: develop the reals (0 ≠ 1 and completeness)

### DIFF
--- a/SKELETONS.md
+++ b/SKELETONS.md
@@ -87,6 +87,21 @@ it is how unfinished work stays discoverable.
     to an `int` order fact (`a·d < c·b ⟹ a·(b+d) < (a+c)·b`, etc.)
     lifted through the quotient — blocked on the same `int` order theory.
 
+- **The `real` Dedekind-cut theory** in
+  `crates/covalence-hol/src/init/real.rs`. `real := close rat ratLe`
+  (upper cuts). **Proved**: `is_cut` (every principal up-set `ratLe q` is a
+  genuine cut, from the `rat` `≤` toolkit) and `zero_ne_one` (`⊢ ¬(0 = 1)`,
+  via distinct principal cuts transported through the subtype `rep`/`abs`).
+  Both are genuine *modulo* the `rat` order postulates they consume.
+  **Postulated** via the module's `axiom` helper (self-flagged):
+  - `sup_is_ub` / `sup_is_least` — the two least-upper-bound properties of
+    the supremum cut `real_sup A` (the intersection of the members'
+    cut-sets). Each unfolds to a set/order fact about the cuts, blocked on
+    the same `rat`/order theory. `complete` (the least-upper-bound property,
+    "the reals are complete") is itself **derived** from these two, with
+    `real_sup A` as the witness — the direct analogue of how `rat::dense`
+    is derived from its mediant postulates.
+
 ## Partial subsystems
 
 - **`covalence-alethe` rule coverage.** `HolAletheBridge` (in

--- a/SKELETONS.md
+++ b/SKELETONS.md
@@ -73,11 +73,14 @@ it is how unfinished work stays discoverable.
     that lands, this becomes the int-analogue of `int_rel_trans`.
   - The ordered-field axioms over `rat_zero`/`rat_one`/`rat_add`/
     `rat_neg`/`rat_mul`/`rat_lt` (commutative-ring `add_*`/`mul_*`/
-    `distrib`, multiplicative inverse `mul_inv`, and the linear order
-    `lt_*`/`le_def`). Each is a HOL theorem derivable from the `int`
-    ordered-ring theory through the quotient; filling them in does not
-    change the public `fn` surface. They depend transitively on the
-    `int` postulates above.
+    `distrib`, multiplicative inverse `mul_inv`, the linear order
+    `lt_*`/`le_def`, and the base strictness fact `zero_lt_one` — `ratLt`
+    picks ε-representatives, so `0 < 1` is not reducible). Each is a HOL
+    theorem derivable from the `int` ordered-ring theory through the
+    quotient; filling them in does not change the public `fn` surface.
+    They depend transitively on the `int` postulates above. (The `≤`
+    toolkit `le_refl`/`lt_imp_le`/`le_trans`/`not_one_le_zero` is **not**
+    postulated — it is *derived* from `le_def` + the strict-order facts.)
   - The two **mediant inequalities** `mediant_gt` / `mediant_lt` — the
     only postulated leaves of `dense` (which is itself *derived* from
     them via the mediant `(a+c)/(b+d)`, no division needed). Each unfolds

--- a/crates/covalence-hol/src/init/mod.rs
+++ b/crates/covalence-hol/src/init/mod.rs
@@ -23,7 +23,7 @@
 //! - [`set`] — the `TypeSpec`-backed set membership / extensionality API.
 //!
 //! plus the per-theory theorem catalogues — [`cond`] (the boolean
-//! conditional's reduction clauses), [`nat`], [`int`], [`rat`],
+//! conditional's reduction clauses), [`nat`], [`int`], [`rat`], [`real`],
 //! [`coprod`], [`option`], [`stream`], [`recursion`], [`rel`], and
 //! [`set`].
 //!

--- a/crates/covalence-hol/src/init/mod.rs
+++ b/crates/covalence-hol/src/init/mod.rs
@@ -64,6 +64,7 @@ pub mod nat;
 pub mod option;
 pub mod quotient;
 pub mod rat;
+pub mod real;
 pub mod recursion;
 pub mod rel;
 pub mod set;

--- a/crates/covalence-hol/src/init/rat.rs
+++ b/crates/covalence-hol/src/init/rat.rs
@@ -39,7 +39,12 @@
 //!   [`rat_add`], [`rat_neg`], [`rat_mul`]) and the strict order
 //!   ([`rat_lt`]) are defined at the representative level; the ordered-
 //!   field axioms over them are **postulated** (same audit-trail style as
-//!   `init::int`), pending the quotient derivations.
+//!   `init::int`), pending the quotient derivations. On top of those, a
+//!   small `≤` toolkit is **derived**: [`le_refl`], [`lt_imp_le`],
+//!   [`le_trans`], and [`not_one_le_zero`] (from [`le_def`] + the strict
+//!   facts + the one base postulate [`zero_lt_one`]). These are what the
+//!   `real` Dedekind-cut construction in [`init::real`](crate::init::real)
+//!   consumes.
 //! - **Density.** [`dense`] — `∀x y. x < y ⟹ ∃z. x < z ∧ z < y` — is
 //!   **derived** from the two mediant-inequality postulates via the
 //!   mediant `(a+c)/(b+d)`, the witness that needs no division.
@@ -47,7 +52,7 @@
 use covalence_core::defs::{fst, int_pos_spec, int_pos_ty, prod, snd};
 use covalence_core::{Result, Term, Thm, Type, subst};
 
-use crate::init::ext::TermExt;
+use crate::init::ext::{TermExt, ThmExt};
 use crate::init::{int, logic, nat};
 
 // Re-export the `defs/rat.rs` catalogue (the type handles + the declared
@@ -511,6 +516,186 @@ pub fn le_def() -> Thm {
 }
 
 // ============================================================================
+// Order toolkit — derived `≤` facts (and the one base strictness postulate)
+// ============================================================================
+//
+// `le_refl` / `lt_imp_le` / `le_trans` are **derived** from `le_def` and the
+// strict-order postulates (`lt_irrefl` / `lt_trans`). The single new
+// postulate is `zero_lt_one` (`0 < 1`) — the base strictness fact reduction
+// cannot reach (`ratLt` picks representatives via ε). `not_one_le_zero`
+// (`¬(1 ≤ 0)`) then follows. These are what the `real` Dedekind-cut proofs
+// (`init::real`) consume: cut upward-closure is `le_trans`, non-emptiness is
+// `le_refl`, and `0 ≠ 1` for reals turns on `not_one_le_zero`.
+
+/// `⊢ 0 < 1` — the base strictness fact (postulated; `ratLt` is stuck at
+/// the ε-chosen representatives, so this is not reducible).
+pub fn zero_lt_one() -> Thm {
+    axiom(rlt(rat_zero(), rat_one()))
+}
+
+cached_thm! {
+    /// `⊢ ∀a. a ≤ a` — reflexivity of `≤`, from `le_def` + `=`-reflexivity.
+    pub fn le_refl() -> Thm {
+        le_refl_impl().expect("le_refl")
+    }
+}
+fn le_refl_impl() -> Result<Thm> {
+    let a = rvar("a");
+    let ld = le_def().all_elim(a.clone())?.all_elim(a.clone())?; // (a≤a) = (a<a ∨ a=a)
+    let disj = Thm::refl(a.clone())?.or_intro_r(rlt(a.clone(), a.clone()))?; // ⊢ a<a ∨ a=a
+    ld.sym()?.eq_mp(disj)?.all_intro("a", rat())
+}
+
+cached_thm! {
+    /// `⊢ ∀a b. a < b ⟹ a ≤ b` — strict implies non-strict.
+    pub fn lt_imp_le() -> Thm {
+        lt_imp_le_impl().expect("lt_imp_le")
+    }
+}
+fn lt_imp_le_impl() -> Result<Thm> {
+    let (a, b) = (rvar("a"), rvar("b"));
+    let lt = rlt(a.clone(), b.clone());
+    let ld = le_def().all_elim(a.clone())?.all_elim(b.clone())?; // (a≤b)=(a<b ∨ a=b)
+    let disj = Thm::assume(lt.clone())?
+        .or_intro_l(a.clone().equals(b.clone())?)?; // {a<b} ⊢ a<b ∨ a=b
+    ld.sym()?
+        .eq_mp(disj)?
+        .imp_intro(&lt)?
+        .all_intro("b", rat())?
+        .all_intro("a", rat())
+}
+
+cached_thm! {
+    /// `⊢ ∀a b c. a ≤ b ⟹ b ≤ c ⟹ a ≤ c` — transitivity of `≤`, by case
+    /// analysis on `le_def` (each `≤` is `<` or `=`) using `lt_trans` and
+    /// equality congruence.
+    pub fn le_trans() -> Thm {
+        le_trans_impl().expect("le_trans")
+    }
+}
+fn le_trans_impl() -> Result<Thm> {
+    let (a, b, c) = (rvar("a"), rvar("b"), rvar("c"));
+    let (hab, hbc) = (rle(a.clone(), b.clone()), rle(b.clone(), c.clone()));
+
+    // Goal disjunction `a<c ∨ a=c`, and the closer `(a<c ∨ a=c) ⟹ a≤c`.
+    let ld_ac = le_def().all_elim(a.clone())?.all_elim(c.clone())?; // (a≤c)=(a<c ∨ a=c)
+    let close_goal = |disj: Thm| -> Result<Thm> { ld_ac.clone().sym()?.eq_mp(disj) };
+
+    // From the two `≤` hyps, the two disjunctions.
+    let d_ab = le_def()
+        .all_elim(a.clone())?
+        .all_elim(b.clone())?
+        .eq_mp(Thm::assume(hab.clone())?)?; // {a≤b} ⊢ a<b ∨ a=b
+    let d_bc = le_def()
+        .all_elim(b.clone())?
+        .all_elim(c.clone())?
+        .eq_mp(Thm::assume(hbc.clone())?)?; // {b≤c} ⊢ b<c ∨ b=c
+
+    // The four leaf derivations of `a≤c`, each as `<branch hyp> ⊢ a≤c`.
+    // a<b, b<c ⟹ a<c.
+    let lt_lt = |ab: Thm, bc: Thm| -> Result<Thm> {
+        let ac = lt_trans()
+            .all_elim(a.clone())?
+            .all_elim(b.clone())?
+            .all_elim(c.clone())?
+            .imp_elim(ab)?
+            .imp_elim(bc)?; // a<c
+        close_goal(ac.or_intro_l(a.clone().equals(c.clone())?)?)
+    };
+    // a<b, b=c ⟹ a<c   (rewrite the `b` in `a<b` to `c`).
+    let lt_eq = |ab: Thm, bc_eq: Thm| -> Result<Thm> {
+        let cong = bc_eq.cong_arg(Term::app(rat_lt(), a.clone()))?; // (a<b)=(a<c)
+        let ac = cong.eq_mp(ab)?; // a<c
+        close_goal(ac.or_intro_l(a.clone().equals(c.clone())?)?)
+    };
+    // a=b, b<c ⟹ a<c   (rewrite the `b` in `b<c` to `a`).
+    let eq_lt = |ab_eq: Thm, bc: Thm| -> Result<Thm> {
+        let cong = ab_eq.cong_arg(rat_lt())?.cong_fn(c.clone())?; // (a<c)=(b<c)
+        let ac = cong.sym()?.eq_mp(bc)?; // a<c
+        close_goal(ac.or_intro_l(a.clone().equals(c.clone())?)?)
+    };
+    // a=b, b=c ⟹ a=c.
+    let eq_eq = |ab_eq: Thm, bc_eq: Thm| -> Result<Thm> {
+        let ac = ab_eq.trans(bc_eq)?; // a=c
+        close_goal(ac.or_intro_r(rlt(a.clone(), c.clone()))?)
+    };
+
+    // Inner case split on `b<c ∨ b=c`, given a fixed left branch builder.
+    let ab_lt = rlt(a.clone(), b.clone());
+    let ab_eq = a.clone().equals(b.clone())?;
+    let bc_lt = rlt(b.clone(), c.clone());
+    let bc_eq = b.clone().equals(c.clone())?;
+
+    // Left of the outer split: assume a<b, case-split d_bc.
+    let outer_left = {
+        let ab = Thm::assume(ab_lt.clone())?;
+        let br_lt = lt_lt(ab.clone(), Thm::assume(bc_lt.clone())?)?.imp_intro(&bc_lt)?;
+        let br_eq = lt_eq(ab, Thm::assume(bc_eq.clone())?)?.imp_intro(&bc_eq)?;
+        d_bc.clone().or_elim(br_lt, br_eq)?.imp_intro(&ab_lt)? // {a≤b,b≤c} ⊢ a<b ⟹ a≤c
+    };
+    // Right of the outer split: assume a=b, case-split d_bc.
+    let outer_right = {
+        let ab = Thm::assume(ab_eq.clone())?;
+        let br_lt = eq_lt(ab.clone(), Thm::assume(bc_lt.clone())?)?.imp_intro(&bc_lt)?;
+        let br_eq = eq_eq(ab, Thm::assume(bc_eq.clone())?)?.imp_intro(&bc_eq)?;
+        d_bc.or_elim(br_lt, br_eq)?.imp_intro(&ab_eq)? // {a≤b,b≤c} ⊢ a=b ⟹ a≤c
+    };
+
+    d_ab.or_elim(outer_left, outer_right)? // {a≤b,b≤c} ⊢ a≤c
+        .imp_intro(&hbc)?
+        .imp_intro(&hab)?
+        .all_intro("c", rat())?
+        .all_intro("b", rat())?
+        .all_intro("a", rat())
+}
+
+cached_thm! {
+    /// `⊢ ¬(1 ≤ 0)` — from `0 < 1` (`zero_lt_one`), `lt_trans` and
+    /// `lt_irrefl`. The distinguishing fact behind `real` `0 ≠ 1`.
+    pub fn not_one_le_zero() -> Thm {
+        not_one_le_zero_impl().expect("not_one_le_zero")
+    }
+}
+fn not_one_le_zero_impl() -> Result<Thm> {
+    let (zero, one) = (rat_zero(), rat_one());
+    let one_le_zero = rle(one.clone(), zero.clone());
+    // (1≤0) = (1<0 ∨ 1=0); under the assumption, the disjunction.
+    let ld = le_def().all_elim(one.clone())?.all_elim(zero.clone())?;
+    let disj = ld.eq_mp(Thm::assume(one_le_zero.clone())?)?; // {1≤0} ⊢ 1<0 ∨ 1=0
+
+    let lt_10 = rlt(one.clone(), zero.clone());
+    let eq_10 = one.clone().equals(zero.clone())?;
+
+    // 1<0 branch: 0<1 and 1<0 give 0<0, contradicting irreflexivity.
+    let br_lt = {
+        let chain = lt_trans()
+            .all_elim(zero.clone())?
+            .all_elim(one.clone())?
+            .all_elim(zero.clone())?
+            .imp_elim(zero_lt_one())?
+            .imp_elim(Thm::assume(lt_10.clone())?)?; // 0<0
+        lt_irrefl()
+            .all_elim(zero.clone())?
+            .not_elim(chain)?
+            .imp_intro(&lt_10)?
+    };
+    // 1=0 branch: rewrite 0<1 by 1=0 to 0<0, same contradiction.
+    let br_eq = {
+        let cong = Thm::assume(eq_10.clone())?.cong_arg(Term::app(rat_lt(), zero.clone()))?; // (0<1)=(0<0)
+        let zero_lt_zero = cong.eq_mp(zero_lt_one())?; // 0<0
+        lt_irrefl()
+            .all_elim(zero.clone())?
+            .not_elim(zero_lt_zero)?
+            .imp_intro(&eq_10)?
+    };
+
+    disj
+        .or_elim(br_lt, br_eq)? // {1≤0, 0<1} ⊢ F
+        .imp_intro(&one_le_zero)?
+        .not_intro()
+}
+
+// ============================================================================
 // Density — DERIVED from the two mediant inequalities
 // ============================================================================
 //
@@ -744,6 +929,33 @@ mod tests {
             assert!(ax.concl().type_of().unwrap().is_bool());
             assert!(ax.hyps().iter().any(|h| h == ax.concl()));
         }
+    }
+
+    #[test]
+    fn order_toolkit_derivations_are_well_typed() {
+        // le_refl / lt_imp_le / le_trans / not_one_le_zero are derived: they
+        // carry only postulate hypotheses (no stray assumptions), are
+        // bool-typed, and have the expected shapes.
+        let a = rvar("a");
+        let refl = le_refl().all_elim(a.clone()).unwrap();
+        assert_eq!(refl.concl(), &rle(a.clone(), a.clone()));
+
+        // not_one_le_zero : ¬(1 ≤ 0), resting on the zero_lt_one postulate.
+        let n = not_one_le_zero();
+        assert_eq!(n.concl(), &rle(rat_one(), rat_zero()).not().unwrap());
+        assert!(n.hyps().iter().all(|h| h.type_of().unwrap().is_bool()));
+
+        // le_trans specialises to a concrete double implication.
+        let (x, y, z) = (rvar("x"), rvar("y"), rvar("z"));
+        let lt = le_trans()
+            .all_elim(x.clone())
+            .and_then(|t| t.all_elim(y.clone()))
+            .and_then(|t| t.all_elim(z.clone()))
+            .unwrap();
+        let expected = rle(x.clone(), y.clone())
+            .imp(rle(y, z.clone()).imp(rle(x, z)).unwrap())
+            .unwrap();
+        assert_eq!(lt.concl(), &expected);
     }
 
     #[test]

--- a/crates/covalence-hol/src/init/real.rs
+++ b/crates/covalence-hol/src/init/real.rs
@@ -1,0 +1,199 @@
+//! `real` theorems: the Dedekind-cut construction of the reals, built on
+//! [`init::rat`](crate::init::rat).
+//!
+//! ## The construction
+//!
+//! `real := close rat ratLe` ([`defs/real.rs`](covalence_core::defs)) is
+//! the type of **upper Dedekind cuts**: a real is a non-empty subset of
+//! `rat` that is upward-closed under `≤`. The carrier of the subtype is
+//! the powerset `rat → bool`, and the selector predicate (the `close`
+//! predicate, [`cut_pred`]) is
+//!
+//! ```text
+//!     λS. (∀x y. ratLe x y ⟹ S x ⟹ S y) ∧ (∃x. S x)
+//! ```
+//!
+//! — "`S` is upward-closed under `≤` and non-empty". We bridge a real and
+//! its cut-set with the kernel subtype coercions: [`mk_real`] (`abs`)
+//! wraps a cut-set into a real and [`cut_of`] (`rep`) recovers it.
+//!
+//! The **principal cut** of a rational `q` is its up-set `{x | q ≤ x}`,
+//! written η-cleanly as the partial application `ratLe q : rat → bool`
+//! (so `(ratLe q) x` is `ratLe q x` with no stray β-redex). [`of_rat`]
+//! embeds `rat` into `real` this way; [`real_zero`] / [`real_one`] are the
+//! principal cuts of `0` / `1`.
+//!
+//! ## Status
+//!
+//! - **Scaffolding** (this layer): the coercions, [`of_rat`], the order
+//!   [`real_le`] (reverse inclusion of cut-sets), and [`real_zero`] /
+//!   [`real_one`].
+//! - **`is_cut`** — `⊢ cut_pred (ratLe q)`, that every principal up-set is
+//!   a genuine cut — is **proved** from the `rat` `≤` toolkit
+//!   (`le_trans` for upward closure, `le_refl` for non-emptiness).
+//! - **[`zero_ne_one`]** — `⊢ ¬(0 = 1)` — is **proved**: distinct
+//!   principal cuts (the rational `0` lies in `ratLe 0` but not `ratLe 1`,
+//!   by `not_one_le_zero`), transported through the subtype `rep`/`abs`.
+//! - **[`complete`]** — the least-upper-bound property — is **derived**
+//!   from the supremum-cut postulates ([`sup_is_ub`], [`sup_is_least`]),
+//!   exactly as `rat::dense` is derived from the mediant postulates: the
+//!   supremum is the *intersection of the cut-sets* ([`real_sup`]).
+
+use covalence_core::defs::{real_spec, real_ty};
+use covalence_core::{Term, Type, subst};
+
+use crate::init::ext::TermExt;
+use crate::init::rat;
+
+// Re-export the `defs/real.rs` catalogue.
+pub use covalence_core::defs::real_ty as real_type;
+
+// ============================================================================
+// Coercions and small term helpers
+// ============================================================================
+
+/// `real` — the reals type.
+fn real() -> Type {
+    real_ty()
+}
+
+/// `rat` — the base type of the cuts.
+fn ratt() -> Type {
+    rat::rat_ty()
+}
+
+/// `rat → bool` — the powerset carrier a cut-set lives in.
+fn powerset() -> Type {
+    Type::fun(ratt(), Type::bool())
+}
+
+/// `abs : (rat→bool) → real` — wrap a cut-set into a real.
+fn real_abs() -> Term {
+    Term::spec_abs(real_spec(), Vec::new())
+}
+/// `rep : real → (rat→bool)` — the cut-set of a real.
+fn real_rep() -> Term {
+    Term::spec_rep(real_spec(), Vec::new())
+}
+
+/// `mkReal S ≔ abs S` — the real whose cut-set is `S : rat→bool`.
+fn mk_real(s: Term) -> Term {
+    Term::app(real_abs(), s)
+}
+/// `cutOf r ≔ rep r : rat→bool` — the cut-set of the real `r`.
+fn cut_of(r: Term) -> Term {
+    Term::app(real_rep(), r)
+}
+
+/// The `close`/cut selector predicate `P : (rat→bool) → bool` — the
+/// `real` subtype's `tm()`.
+fn cut_pred() -> Term {
+    real_spec()
+        .tm()
+        .expect("real is a close-subtype with a selector predicate")
+        .clone()
+}
+
+/// `ratLe q : rat → bool` — the principal upper cut `{x | q ≤ x}` of a
+/// rational `q`, η-cleanly as a partial application.
+fn upper_cut(q: Term) -> Term {
+    Term::app(rat::rat_le(), q)
+}
+
+// ============================================================================
+// Embedding ℚ ↪ ℝ and the order
+// ============================================================================
+
+/// `of_rat : rat → real` ≡ `λq. mkReal (ratLe q)` — the principal-cut
+/// embedding of the rationals.
+pub fn of_rat() -> Term {
+    let q = Term::free("q", ratt());
+    let body = mk_real(upper_cut(q.clone()));
+    Term::abs(ratt(), subst::close(&body, "q"))
+}
+
+/// `0 : real` ≡ the principal cut of `rat`'s `0`.
+pub fn real_zero() -> Term {
+    mk_real(upper_cut(rat::rat_zero()))
+}
+
+/// `1 : real` ≡ the principal cut of `rat`'s `1`.
+pub fn real_one() -> Term {
+    mk_real(upper_cut(rat::rat_one()))
+}
+
+/// `realLe : real → real → bool` ≡ `λr s. ∀q. cutOf s q ⟹ cutOf r q` —
+/// the order on reals as **reverse inclusion** of cut-sets (a larger real
+/// has a smaller up-set).
+pub fn real_le() -> Term {
+    let (r, s) = (Term::free("r", real()), Term::free("s", real()));
+    let q = Term::free("q", ratt());
+    let body = Term::app(cut_of(s.clone()), q.clone())
+        .imp(Term::app(cut_of(r.clone()), q))
+        .expect("real_le: body")
+        .forall("q", ratt())
+        .expect("real_le: ∀q");
+    Term::abs(
+        real(),
+        subst::close(&Term::abs(real(), subst::close(&body, "s")), "r"),
+    )
+}
+
+/// `r ≤ s` on `real`.
+fn rle(r: Term, s: Term) -> Term {
+    Term::app(Term::app(real_le(), r), s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_ty_matches_the_catalogue() {
+        assert_eq!(real(), covalence_core::defs::real_ty());
+        assert!(!real().is_bool());
+    }
+
+    #[test]
+    fn carrier_is_the_rational_powerset() {
+        // abs : (rat→bool) → real ; rep : real → (rat→bool).
+        assert_eq!(
+            real_abs().type_of().unwrap(),
+            Type::fun(powerset(), real())
+        );
+        assert_eq!(
+            real_rep().type_of().unwrap(),
+            Type::fun(real(), powerset())
+        );
+    }
+
+    #[test]
+    fn embedding_and_constants_have_expected_types() {
+        assert_eq!(of_rat().type_of().unwrap(), Type::fun(ratt(), real()));
+        assert_eq!(real_zero().type_of().unwrap(), real());
+        assert_eq!(real_one().type_of().unwrap(), real());
+    }
+
+    #[test]
+    fn real_le_is_a_binary_relation() {
+        assert_eq!(
+            real_le().type_of().unwrap(),
+            Type::fun(real(), Type::fun(real(), Type::bool()))
+        );
+        // `r ≤ s` is a bool.
+        let (r, s) = (Term::free("r", real()), Term::free("s", real()));
+        assert!(rle(r, s).type_of().unwrap().is_bool());
+    }
+
+    #[test]
+    fn cut_pred_is_the_close_predicate() {
+        // cut_pred : (rat→bool) → bool.
+        assert_eq!(
+            cut_pred().type_of().unwrap(),
+            Type::fun(powerset(), Type::bool())
+        );
+        // It applies to a principal cut to give a bool statement.
+        let p = Term::app(cut_pred(), upper_cut(rat::rat_zero()));
+        assert!(p.type_of().unwrap().is_bool());
+    }
+}

--- a/crates/covalence-hol/src/init/real.rs
+++ b/crates/covalence-hol/src/init/real.rs
@@ -40,10 +40,10 @@
 //!   supremum is the *intersection of the cut-sets* ([`real_sup`]).
 
 use covalence_core::defs::{real_spec, real_ty};
-use covalence_core::{Term, Type, subst};
+use covalence_core::{Result, Term, Thm, Type, subst};
 
-use crate::init::ext::TermExt;
-use crate::init::rat;
+use crate::init::ext::{TermExt, ThmExt};
+use crate::init::{logic, rat};
 
 // Re-export the `defs/real.rs` catalogue.
 pub use covalence_core::defs::real_ty as real_type;
@@ -144,6 +144,109 @@ fn rle(r: Term, s: Term) -> Term {
     Term::app(Term::app(real_le(), r), s)
 }
 
+/// `ratLe a b` — a rational `≤` atom.
+fn rat_le_app(a: &Term, b: &Term) -> Term {
+    Term::app(Term::app(rat::rat_le(), a.clone()), b.clone())
+}
+
+// ============================================================================
+// Principal up-sets are genuine cuts
+// ============================================================================
+
+/// `⊢ cut_pred (ratLe q)` — every principal up-set `{x | q ≤ x}` is a
+/// Dedekind cut. **Proved** from the `rat` `≤` toolkit: upward closure is
+/// `le_trans` (`q ≤ x` and `x ≤ y` give `q ≤ y`), non-emptiness is
+/// `le_refl` (the witness `q` lies in its own up-set).
+///
+/// The conclusion is the *un-reduced* redex `cut_pred (ratLe q)` — exactly
+/// the antecedent [`Thm::spec_rep_abs_fwd`] expects — obtained by proving
+/// the β-reduced conjunction and transporting back across `beta_conv`.
+fn is_cut(q: &Term) -> Result<Thm> {
+    let s = upper_cut(q.clone()); // ratLe q : rat→bool
+    let pred_app = Term::app(cut_pred(), s);
+    let conv = Thm::beta_conv(pred_app)?; // ⊢ pred_app = (closed ∧ nonempty)
+    let clean = conv.concl().as_eq().expect("beta_conv yields an equation").1.clone();
+
+    // clean = and closed nonempty = App(App(and, closed), nonempty).
+    let (and_closed, nonempty_t) = clean.as_app().expect("clean is a conjunction");
+    let closed_t = and_closed.as_app().expect("clean is a conjunction").1.clone();
+    let nonempty_t = nonempty_t.clone();
+
+    // closed: ∀x y. x≤y ⟹ q≤x ⟹ q≤y, via le_trans q x y (antecedents reordered).
+    let closed_thm = {
+        let (x, y) = (Term::free("x", ratt()), Term::free("y", ratt()));
+        let xy = rat_le_app(&x, &y);
+        let qx = rat_le_app(q, &x);
+        let qy = rat::le_trans()
+            .all_elim(q.clone())?
+            .all_elim(x.clone())?
+            .all_elim(y.clone())?
+            .imp_elim(Thm::assume(qx.clone())?)?
+            .imp_elim(Thm::assume(xy.clone())?)?; // {q≤x, x≤y} ⊢ q≤y
+        qy.imp_intro(&qx)?
+            .imp_intro(&xy)?
+            .all_intro("y", ratt())?
+            .all_intro("x", ratt())?
+    };
+
+    // nonempty: ∃x. q≤x, witness q, proof le_refl q (β-expanded to `pred q`).
+    let nonempty_thm = {
+        let pred = nonempty_t.as_app().expect("nonempty is `exists pred`").1.clone();
+        let refl = rat::le_refl().all_elim(q.clone())?; // ⊢ q≤q
+        let pf = Thm::beta_conv(Term::app(pred.clone(), q.clone()))?
+            .sym()?
+            .eq_mp(refl)?; // ⊢ pred q
+        logic::exists_intro(pred, q.clone(), pf)? // ⊢ ∃x. q≤x
+    };
+
+    // Re-assemble the conjunction and transport back to the redex.
+    debug_assert_eq!(closed_thm.concl(), &closed_t);
+    let p_clean = closed_thm.and_intro(nonempty_thm)?; // ⊢ closed ∧ nonempty
+    conv.sym()?.eq_mp(p_clean) // ⊢ cut_pred (ratLe q)
+}
+
+// ============================================================================
+// 0 ≠ 1
+// ============================================================================
+
+cached_thm! {
+    /// `⊢ ¬(0 = 1)` — zero and one are distinct reals.
+    ///
+    /// **Proved.** The principal cuts `ratLe 0` and `ratLe 1` differ at the
+    /// rational `0`: `0 ≤ 0` holds (`le_refl`) but `1 ≤ 0` does not
+    /// (`not_one_le_zero`). Assuming `0 = 1`, congruence under `rep` plus
+    /// the subtype round-trip [`Thm::spec_rep_abs_fwd`] (discharged by
+    /// [`is_cut`]) collapses the two cut-sets, so `0 ≤ 0 = 1 ≤ 0`,
+    /// contradicting `not_one_le_zero`. Genuine *modulo* the `rat` order
+    /// postulates `is_cut` / `not_one_le_zero` rest on.
+    pub fn zero_ne_one() -> Thm {
+        zero_ne_one_impl().expect("real zero_ne_one")
+    }
+}
+fn zero_ne_one_impl() -> Result<Thm> {
+    let (zero, one) = (rat::rat_zero(), rat::rat_one());
+    let (s0, s1) = (upper_cut(zero.clone()), upper_cut(one.clone()));
+    let eq01 = real_zero().equals(real_one())?; // abs s0 = abs s1
+
+    // rep both sides of the assumed equality.
+    let reps_eq = Thm::assume(eq01.clone())?.cong_arg(real_rep())?; // {eq} ⊢ rep(abs s0)=rep(abs s1)
+    // rep(abs sᵢ) = sᵢ, the subtype round-trip discharged by `is_cut`.
+    let r0 = Thm::spec_rep_abs_fwd(real_spec(), Vec::new(), s0)?.imp_elim(is_cut(&zero)?)?;
+    let r1 = Thm::spec_rep_abs_fwd(real_spec(), Vec::new(), s1)?.imp_elim(is_cut(&one)?)?;
+    let sets_eq = r0.sym()?.trans(reps_eq)?.trans(r1)?; // {eq} ⊢ s0 = s1
+
+    // Evaluate both cut-sets at the rational 0: (0≤0) = (1≤0).
+    let at0 = sets_eq.cong_fn(zero.clone())?; // {eq} ⊢ ratLe 0 0 = ratLe 1 0
+    let le00 = rat::le_refl().all_elim(zero.clone())?; // ⊢ ratLe 0 0
+    let le10 = at0.eq_mp(le00)?; // {eq} ⊢ ratLe 1 0
+
+    // ¬(1≤0) gives the contradiction.
+    rat::not_one_le_zero()
+        .not_elim(le10)? // {eq, …} ⊢ F
+        .imp_intro(&eq01)?
+        .not_intro() // ⊢ ¬(0 = 1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,6 +286,38 @@ mod tests {
         // `r ≤ s` is a bool.
         let (r, s) = (Term::free("r", real()), Term::free("s", real()));
         assert!(rle(r, s).type_of().unwrap().is_bool());
+    }
+
+    #[test]
+    fn is_cut_proves_a_principal_up_set_is_a_cut() {
+        // A concrete rational (`is_cut` is only ever called on closed
+        // rationals; `exists_intro` reserves the name `q` internally).
+        let q = rat::rat_zero();
+        let thm = is_cut(&q).expect("is_cut q");
+        // Conclusion is exactly the redex `cut_pred (ratLe q)`.
+        assert_eq!(thm.concl(), &Term::app(cut_pred(), upper_cut(q)));
+        assert!(thm.concl().type_of().unwrap().is_bool());
+    }
+
+    #[test]
+    fn zero_is_distinct_from_one() {
+        let thm = zero_ne_one();
+        // Statement: ¬(0 = 1).
+        assert_eq!(
+            thm.concl(),
+            &real_zero().equals(real_one()).unwrap().not().unwrap()
+        );
+        // Genuine modulo the rat-order postulates: the assumed `0 = 1` is
+        // discharged, so no equation hypothesis remains — only bool
+        // (postulate) hyps.
+        let eq01 = real_zero().equals(real_one()).unwrap();
+        assert!(
+            !thm.hyps().iter().any(|h| h == &eq01),
+            "the assumed equality is discharged"
+        );
+        for h in thm.hyps() {
+            assert!(h.type_of().unwrap().is_bool());
+        }
     }
 
     #[test]

--- a/crates/covalence-hol/src/init/real.rs
+++ b/crates/covalence-hol/src/init/real.rs
@@ -62,11 +62,6 @@ fn ratt() -> Type {
     rat::rat_ty()
 }
 
-/// `rat → bool` — the powerset carrier a cut-set lives in.
-fn powerset() -> Type {
-    Type::fun(ratt(), Type::bool())
-}
-
 /// `abs : (rat→bool) → real` — wrap a cut-set into a real.
 fn real_abs() -> Term {
     Term::spec_abs(real_spec(), Vec::new())
@@ -247,9 +242,168 @@ fn zero_ne_one_impl() -> Result<Thm> {
         .not_intro() // ⊢ ¬(0 = 1)
 }
 
+// ============================================================================
+// Completeness — the least-upper-bound property
+// ============================================================================
+//
+// Derived from the supremum-cut postulates exactly as `rat::dense` is
+// derived from the mediant postulates: the least upper bound of a set `A`
+// of reals is the **intersection of their cut-sets**, `real_sup A`, and the
+// two postulated leaves assert that this intersection *is* an upper bound
+// and *is* the least one. Both unfold to set/order facts about the cuts,
+// blocked on the same `rat`/order theory the rest of the tower waits on
+// (`SKELETONS.md`); `complete` itself is a genuine derivation from them.
+
+/// Postulate a `real` axiom: `{t} ⊢ t` (self-flagged audit trail, as in
+/// `init::int` / `init::rat`).
+fn axiom(t: Term) -> Thm {
+    Thm::assume(t).expect("init::real::axiom: term must be bool-typed")
+}
+
+/// `real → bool` — a set of reals.
+fn real_set() -> Type {
+    Type::fun(real(), Type::bool())
+}
+
+/// `is_ub A u ≔ ∀a. A a ⟹ a ≤ u` — `u` is an upper bound of `A`.
+fn is_ub(a_set: &Term, u: &Term) -> Term {
+    let a = Term::free("a", real());
+    Term::app(a_set.clone(), a.clone())
+        .imp(rle(a, u.clone()))
+        .expect("is_ub: body")
+        .forall("a", real())
+        .expect("is_ub: ∀a")
+}
+
+/// `is_lub A s ≔ is_ub A s ∧ (∀u. is_ub A u ⟹ s ≤ u)` — `s` is the least
+/// upper bound of `A`.
+fn is_lub(a_set: &Term, s: &Term) -> Term {
+    let u = Term::free("u", real());
+    let least = is_ub(a_set, &u)
+        .imp(rle(s.clone(), u))
+        .expect("is_lub: least body")
+        .forall("u", real())
+        .expect("is_lub: ∀u");
+    is_ub(a_set, s).and(least).expect("is_lub: conjunction")
+}
+
+/// `nonempty A ≔ ∃a. A a`.
+fn nonempty(a_set: &Term) -> Term {
+    let a = Term::free("a", real());
+    Term::app(a_set.clone(), a)
+        .exists("a", real())
+        .expect("nonempty: ∃a")
+}
+
+/// `bounded A ≔ ∃u. is_ub A u` — `A` is bounded above.
+fn bounded(a_set: &Term) -> Term {
+    let u = Term::free("u", real());
+    is_ub(a_set, &u).exists("u", real()).expect("bounded: ∃u")
+}
+
+/// `realSup : (real→bool) → real` ≡ `λA. mkReal (λq. ∀a. A a ⟹ cutOf a q)`
+/// — the supremum as the **intersection of the cut-sets** of the members
+/// of `A` (for upper cuts, sup = intersection).
+pub fn real_sup() -> Term {
+    let a_set = Term::free("A", real_set());
+    let q = Term::free("q", ratt());
+    let a = Term::free("a", real());
+    let inner = Term::app(a_set.clone(), a.clone())
+        .imp(Term::app(cut_of(a), q.clone()))
+        .expect("real_sup: ∀a body")
+        .forall("a", real())
+        .expect("real_sup: ∀a");
+    let cutset = Term::abs(ratt(), subst::close(&inner, "q")); // λq. ∀a. A a ⟹ rep a q
+    let body = mk_real(cutset);
+    Term::abs(real_set(), subst::close(&body, "A"))
+}
+/// `realSup A` applied.
+fn sup(a_set: &Term) -> Term {
+    Term::app(real_sup(), a_set.clone())
+}
+
+/// `⊢ ∀A. nonempty A ⟹ bounded A ⟹ is_ub A (realSup A)` — the supremum
+/// cut is an upper bound. **Postulated** (audit hyp); unfolds to "a
+/// rational in every member-cut is `≥` every member" — a set/order fact
+/// about the cuts (`SKELETONS.md`).
+pub fn sup_is_ub() -> Thm {
+    let a_set = Term::free("A", real_set());
+    let concl = is_ub(&a_set, &sup(&a_set));
+    let body = nonempty(&a_set)
+        .imp(bounded(&a_set).imp(concl).expect("sup_is_ub inner"))
+        .expect("sup_is_ub");
+    axiom(body.forall("A", real_set()).expect("sup_is_ub: ∀A"))
+}
+
+/// `⊢ ∀A. nonempty A ⟹ bounded A ⟹ ∀u. is_ub A u ⟹ realSup A ≤ u` — the
+/// supremum cut is the *least* upper bound. **Postulated** (audit hyp);
+/// unfolds to "the intersection-cut contains every upper-bound cut" — the
+/// dual set/order fact (`SKELETONS.md`).
+pub fn sup_is_least() -> Thm {
+    let a_set = Term::free("A", real_set());
+    let u = Term::free("u", real());
+    let inner = is_ub(&a_set, &u)
+        .imp(rle(sup(&a_set), u))
+        .expect("sup_is_least: u body")
+        .forall("u", real())
+        .expect("sup_is_least: ∀u");
+    let body = nonempty(&a_set)
+        .imp(bounded(&a_set).imp(inner).expect("sup_is_least inner"))
+        .expect("sup_is_least");
+    axiom(body.forall("A", real_set()).expect("sup_is_least: ∀A"))
+}
+
+cached_thm! {
+    /// `⊢ ∀A. nonempty A ⟹ bounded A ⟹ ∃s. is_lub A s` — **the reals are
+    /// complete** (the least-upper-bound property).
+    ///
+    /// A genuine derivation: the witness is the supremum cut [`real_sup`]
+    /// `A` (the intersection of the members' cut-sets); [`sup_is_ub`] and
+    /// [`sup_is_least`] are its two least-upper-bound properties, packaged
+    /// by `∧`- and `∃`-introduction. The only postulated leaves are those
+    /// two; discharging them makes this hypothesis-free. (Same shape as
+    /// `rat::dense` over its mediant postulates.)
+    pub fn complete() -> Thm {
+        complete_impl().expect("completeness derivation")
+    }
+}
+fn complete_impl() -> Result<Thm> {
+    let a_set = Term::free("A", real_set());
+    let (ne, bd) = (nonempty(&a_set), bounded(&a_set));
+    let s = sup(&a_set);
+
+    // {ne, bd} ⊢ is_ub A s   and   {ne, bd} ⊢ ∀u. is_ub A u ⟹ s ≤ u.
+    let ub = sup_is_ub()
+        .all_elim(a_set.clone())?
+        .imp_elim(Thm::assume(ne.clone())?)?
+        .imp_elim(Thm::assume(bd.clone())?)?;
+    let least = sup_is_least()
+        .all_elim(a_set.clone())?
+        .imp_elim(Thm::assume(ne.clone())?)?
+        .imp_elim(Thm::assume(bd.clone())?)?;
+    let lub = ub.and_intro(least)?; // {ne, bd} ⊢ is_lub A s
+
+    // ∃s. is_lub A s, with witness the supremum cut.
+    let s_var = Term::free("s", real());
+    let pred = Term::abs(real(), subst::close(&is_lub(&a_set, &s_var), "s"));
+    let pf = Thm::beta_conv(Term::app(pred.clone(), s.clone()))?
+        .sym()?
+        .eq_mp(lub)?; // {ne, bd} ⊢ pred s
+    let ex = logic::exists_intro(pred, s, pf)?; // {ne, bd} ⊢ ∃s. is_lub A s
+
+    ex.imp_intro(&bd)?
+        .imp_intro(&ne)?
+        .all_intro("A", real_set())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `rat → bool` — the powerset carrier a cut-set lives in.
+    fn powerset() -> Type {
+        Type::fun(ratt(), Type::bool())
+    }
 
     #[test]
     fn real_ty_matches_the_catalogue() {
@@ -315,6 +469,42 @@ mod tests {
             !thm.hyps().iter().any(|h| h == &eq01),
             "the assumed equality is discharged"
         );
+        for h in thm.hyps() {
+            assert!(h.type_of().unwrap().is_bool());
+        }
+    }
+
+    #[test]
+    fn sup_postulates_and_completeness_are_well_formed() {
+        // real_sup : (real→bool) → real.
+        assert_eq!(
+            real_sup().type_of().unwrap(),
+            Type::fun(real_set(), real())
+        );
+        // The two sup postulates are self-flagged bool statements.
+        for ax in [sup_is_ub(), sup_is_least()] {
+            assert!(ax.concl().type_of().unwrap().is_bool());
+            assert!(ax.hyps().iter().any(|h| h == ax.concl()));
+        }
+    }
+
+    #[test]
+    fn completeness_is_derived_from_the_sup_postulates() {
+        let thm = complete();
+        // Shape: ∀A. nonempty A ⟹ bounded A ⟹ ∃s. is_lub A s. Specialise A.
+        let a_set = Term::free("A", real_set());
+        let inst = thm.clone().all_elim(a_set.clone()).unwrap();
+        let s = Term::free("s", real());
+        let pred = Term::abs(real(), subst::close(&is_lub(&a_set, &s), "s"));
+        let exists_lub = Term::app(covalence_core::defs::exists(real()), pred);
+        let expected = nonempty(&a_set)
+            .imp(bounded(&a_set).imp(exists_lub).unwrap())
+            .unwrap();
+        assert_eq!(inst.concl(), &expected);
+
+        // Genuine modulo exactly the two sup postulates: those are the only
+        // hypotheses (each a bool statement).
+        assert_eq!(thm.hyps().len(), 2, "only the two sup postulates remain");
         for h in thm.hyps() {
             assert!(h.type_of().unwrap().is_bool());
         }


### PR DESCRIPTION
Develops the theory of the real numbers in `init/real.rs`, on top of the `rat` work. `real := close rat ratLe` — upper Dedekind cuts of the rationals.

The two headline results requested:

- **`zero_ne_one` — `⊢ ¬(0 = 1)`** (proved)
- **`complete` — the least-upper-bound property** (the reals are complete)

## Commits

1. **`rat`: derived ≤ order toolkit for the reals.** On top of the existing strict-order postulates, adds the `≤` facts the cut proofs need: `zero_lt_one` (the one new base postulate — `ratLt` is stuck at ε-representatives so `0 < 1` isn't reducible), and the *derived* `le_refl`, `lt_imp_le`, `le_trans` (4-case analysis via `le_def` + `lt_trans` + congruence), and `not_one_le_zero`.

2. **`real`: lift the Dedekind-cut definition.** The subtype coercions `mk_real`/`cut_of`, the `close` selector accessor `cut_pred`, the principal-cut embedding `of_rat` (`q ↦ ratLe q`, written η-cleanly as a partial application so cut membership has no stray β-redex), `real_zero`/`real_one`, and `real_le` (reverse inclusion of cut-sets).

3. **`real`: prove 0 ≠ 1.** `is_cut` shows every principal up-set is a genuine cut (upward closure = `le_trans`, non-emptiness = `le_refl`); `zero_ne_one` distinguishes the cuts of 0 and 1 at the rational 0 (`0 ≤ 0` holds, `1 ≤ 0` does not) and transports the assumed real equality down through the subtype `rep`/`abs` round-trip (`spec_rep_abs_fwd`, discharged by `is_cut`) to that rational contradiction.

4. **`real`: the reals are complete.** The lub vocabulary (`is_ub`/`is_lub`/`nonempty`/`bounded`) over `real_le`; `real_sup` as the intersection of the members' cut-sets; the two postulated lub properties `sup_is_ub`/`sup_is_least`; and `complete` (`∀A. nonempty A ⟹ bounded A ⟹ ∃s. is_lub A s`) **derived** from those two with `real_sup A` as the witness.

## Honesty / provenance

Mirrors the `rat` philosophy: prove what's clean, *derive* the headline results from a small, clearly-named set of postulated leaves, and record everything in `SKELETONS.md`.

- `zero_ne_one` and `is_cut` are genuine **modulo the `rat` order postulates** they consume (carried as audit hypotheses).
- `complete` is a genuine derivation carrying **exactly** the two supremum-cut postulates (`sup_is_ub`, `sup_is_least`) as hypotheses — verified in a test — the same derive-from-named-leaves shape as `rat::dense` over its mediant postulates. Discharging those (blocked on the rat/set order theory) makes it hypothesis-free.

## Tests

Full `covalence-hol` suite green (153 tests), no warnings. New tests assert the statements' shapes and that the derivations carry only their intended postulate hypotheses.

> [!NOTE]
> Base is `claude/covalence-hol-rat-init-hxactv` (the `rat` PR) so this stacks on top of it; retarget to the default branch once that lands.

https://claude.ai/code/session_01UwvCd5rTiCBt7fsAAw2c9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwvCd5rTiCBt7fsAAw2c9U)_