### PR TITLE
covalence-hol: point-free monoidal API over the coproduct

### DIFF
--- a/crates/covalence-hol/src/init/cat.rs
+++ b/crates/covalence-hol/src/init/cat.rs
@@ -36,7 +36,7 @@ pub use covalence_core::defs::{compose, compose_spec, flip, id, id_spec, konst};
 fn fun_parts(ty: &Type) -> Result<(Type, Type)> {
     match ty.kind() {
         TypeKind::Fun(dom, cod) => Ok((dom.clone(), cod.clone())),
-        _ => Err(Error::NotBool(ty.clone())),
+        _ => Err(Error::NotFunction(ty.clone())),
     }
 }
 
@@ -44,12 +44,13 @@ fn fun_parts(ty: &Type) -> Result<(Type, Type)> {
 /// and `g : β → γ`. Errors if either is not a function or the middle
 /// objects disagree.
 pub fn comp(g: &Term, f: &Term) -> Result<Term> {
+    let g_ty = g.type_of()?;
     let (alpha, beta) = fun_parts(&f.type_of()?)?;
-    let (beta2, gamma) = fun_parts(&g.type_of()?)?;
+    let (beta2, gamma) = fun_parts(&g_ty)?;
     if beta != beta2 {
         return Err(Error::TypeMismatch {
             expected: Type::fun(beta, gamma),
-            got: g.type_of()?,
+            got: g_ty,
         });
     }
     compose(alpha, beta2, gamma)
@@ -64,7 +65,7 @@ pub fn comp(g: &Term, f: &Term) -> Result<Term> {
 /// `⊢ t = nf`, the applicative normal form of a `compose` / `id` term:
 /// δ-unfold every `compose`, β-reduce, δ-unfold every `id`, β-reduce.
 /// Free morphism variables and other heads are left untouched, so a term
-/// like `(h ∘ g) ∘ f) x` lands on `h (g (f x))`.
+/// like `((h ∘ g) ∘ f) x` lands on `h (g (f x))`.
 fn normalize(t: &Term) -> Result<Thm> {
     let compose_spec = compose_spec();
     let id_spec = id_spec();

--- a/crates/covalence-hol/src/init/cat.rs
+++ b/crates/covalence-hol/src/init/cat.rs
@@ -1,0 +1,218 @@
+//! `cat` — the **category** structure on HOL functions, point-free.
+//!
+//! HOL types are the objects and total functions `α → β` are the
+//! morphisms of a category: composition is [`compose`] (`fun.compose`,
+//! `λg f x. g (f x)`) and the identities are [`id`] (`fun.id`, `λx. x`).
+//! These combinators already live in `defs/fun.rs`; this module pairs
+//! them with the three **category laws** as genuine, hypothesis- and
+//! oracle-free HOL theorems:
+//!
+//! ```text
+//!     ⊢ id ∘ f = f            (id_left)
+//!     ⊢ f ∘ id = f            (id_right)
+//!     ⊢ (h ∘ g) ∘ f = h ∘ (g ∘ f)   (comp_assoc)
+//! ```
+//!
+//! Each is proved the point-free way: apply both sides to a fresh point,
+//! δ-unfold `compose` / `id` and β-reduce to a common applicative normal
+//! form, then re-abstract and η-contract (function extensionality, built
+//! from [`Thm::abs`] + [`Thm::eta_conv`]). The same machinery is exposed
+//! as [`comp`] (typed composition of two morphism *terms*) and
+//! [`comp_cong`] (the congruence that lets composition act on equational
+//! proofs), which the higher-level
+//! [`monoidal`](crate::monoidal) API builds on.
+
+use covalence_core::{Error, Result, Term, Thm, Type, TypeKind};
+
+use crate::init::ext::{TermExt, ThmExt};
+
+pub use covalence_core::defs::{compose, compose_spec, flip, id, id_spec, konst};
+
+// ============================================================================
+// Typed composition of morphism terms.
+// ============================================================================
+
+/// Split a function type `α → β` into `(α, β)`.
+fn fun_parts(ty: &Type) -> Result<(Type, Type)> {
+    match ty.kind() {
+        TypeKind::Fun(dom, cod) => Ok((dom.clone(), cod.clone())),
+        _ => Err(Error::NotBool(ty.clone())),
+    }
+}
+
+/// `g ∘ f` — [`compose`] instantiated at the types read off `f : α → β`
+/// and `g : β → γ`. Errors if either is not a function or the middle
+/// objects disagree.
+pub fn comp(g: &Term, f: &Term) -> Result<Term> {
+    let (alpha, beta) = fun_parts(&f.type_of()?)?;
+    let (beta2, gamma) = fun_parts(&g.type_of()?)?;
+    if beta != beta2 {
+        return Err(Error::TypeMismatch {
+            expected: Type::fun(beta, gamma),
+            got: g.type_of()?,
+        });
+    }
+    compose(alpha, beta2, gamma)
+        .apply(g.clone())?
+        .apply(f.clone())
+}
+
+// ============================================================================
+// Point-free normalisation + function extensionality.
+// ============================================================================
+
+/// `⊢ t = nf`, the applicative normal form of a `compose` / `id` term:
+/// δ-unfold every `compose`, β-reduce, δ-unfold every `id`, β-reduce.
+/// Free morphism variables and other heads are left untouched, so a term
+/// like `(h ∘ g) ∘ f) x` lands on `h (g (f x))`.
+fn normalize(t: &Term) -> Result<Thm> {
+    let compose_spec = compose_spec();
+    let id_spec = id_spec();
+    t.delta_all(compose_spec.symbol())?
+        .rhs_conv(|r| r.reduce())?
+        .rhs_conv(|r| r.delta_all(id_spec.symbol()))?
+        .rhs_conv(|r| r.reduce())
+}
+
+/// Prove `⊢ lhs = rhs` for two morphisms `α → β` that share an
+/// applicative normal form, by extensionality: both `lhs x` and `rhs x`
+/// [`normalize`] to the same term, then re-abstract and η-contract.
+///
+/// `lhs` / `rhs` must not contain a free `__catx` variable (they are
+/// closed combinators over the caller's morphism variables, so this
+/// holds).
+fn ext_eq(lhs: Term, rhs: Term, alpha: &Type) -> Result<Thm> {
+    let x = Term::free("__catx", alpha.clone());
+    let l_nf = normalize(&Term::app(lhs, x.clone()))?; // ⊢ lhs x = nf
+    let r_nf = normalize(&Term::app(rhs, x))?; // ⊢ rhs x = nf
+    let app_eq = l_nf.trans(r_nf.sym()?)?; // ⊢ lhs x = rhs x
+    fun_ext(app_eq, "__catx", alpha)
+}
+
+/// Function extensionality. From `⊢ lhs x = rhs x` — where `x =
+/// Free(name, α)` is not free in `lhs` / `rhs` — derive `⊢ lhs = rhs` by
+/// re-abstracting and η-contracting both sides. The point variable can be
+/// any chosen fresh name; callers building the pointwise equation supply
+/// it.
+pub fn fun_ext(app_eq: Thm, name: &str, alpha: &Type) -> Result<Thm> {
+    let abs_eq = app_eq.abs(name, alpha.clone())?; // ⊢ (λx. lhs x) = (λx. rhs x)
+    let (l_abs, r_abs) = {
+        let (l, r) = abs_eq.concl().as_eq().ok_or(Error::NotAnEquation)?;
+        (l.clone(), r.clone())
+    };
+    let eta_l = Thm::eta_conv(l_abs)?; // ⊢ (λx. lhs x) = lhs
+    let eta_r = Thm::eta_conv(r_abs)?; // ⊢ (λx. rhs x) = rhs
+    eta_l.sym()?.trans(abs_eq)?.trans(eta_r)
+}
+
+// ============================================================================
+// The category laws.
+// ============================================================================
+
+/// `⊢ id ∘ f = f` — left identity. `f : α → β`, `id` at `β`.
+pub fn id_left(f: &Term) -> Result<Thm> {
+    let (alpha, beta) = fun_parts(&f.type_of()?)?;
+    let lhs = comp(&id(beta), f)?;
+    ext_eq(lhs, f.clone(), &alpha)
+}
+
+/// `⊢ f ∘ id = f` — right identity. `f : α → β`, `id` at `α`.
+pub fn id_right(f: &Term) -> Result<Thm> {
+    let (alpha, _beta) = fun_parts(&f.type_of()?)?;
+    let lhs = comp(f, &id(alpha.clone()))?;
+    ext_eq(lhs, f.clone(), &alpha)
+}
+
+/// `⊢ (h ∘ g) ∘ f = h ∘ (g ∘ f)` — associativity. `f : α → β`,
+/// `g : β → γ`, `h : γ → δ`.
+pub fn comp_assoc(h: &Term, g: &Term, f: &Term) -> Result<Thm> {
+    let (alpha, _beta) = fun_parts(&f.type_of()?)?;
+    let lhs = comp(&comp(h, g)?, f)?;
+    let rhs = comp(h, &comp(g, f)?)?;
+    ext_eq(lhs, rhs, &alpha)
+}
+
+/// `⊢ (g ∘ f) x = g (f x)` — δβ-unfold a single composition applied to a
+/// point. Only the **outermost** `∘` is reduced (via [`delta_head`]), so
+/// `g` / `f` may themselves contain compositions (or copairings) that are
+/// left intact — essential when reducing composites of structure
+/// morphisms.
+pub fn comp_beta(gf: &Term, x: &Term) -> Result<Thm> {
+    crate::init::eq::delta_head(&Term::app(gf.clone(), x.clone()))?.rhs_conv(|t| t.reduce())
+}
+
+// ============================================================================
+// Congruence — composition acting on equational proofs.
+// ============================================================================
+
+/// From `⊢ g = g'` and `⊢ f = f'` conclude `⊢ g ∘ f = g' ∘ f'` — the
+/// bifunctoriality of `∘` on morphisms, i.e. the congruence that lets a
+/// proof be whiskered on either side. `f : α → β`, `g : β → γ`.
+pub fn comp_cong(g_eq: &Thm, f_eq: &Thm) -> Result<Thm> {
+    let (g, _g2) = g_eq.concl().as_eq().ok_or(Error::NotAnEquation)?;
+    let (f, _f2) = f_eq.concl().as_eq().ok_or(Error::NotAnEquation)?;
+    let (alpha, beta) = fun_parts(&f.type_of()?)?;
+    let (_beta2, gamma) = fun_parts(&g.type_of()?)?;
+    Thm::refl(compose(alpha, beta, gamma))?
+        .cong_app(g_eq.clone())?
+        .cong_app(f_eq.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ab() -> (Type, Type) {
+        (Type::tfree("a"), Type::tfree("b"))
+    }
+
+    #[test]
+    fn id_left_is_genuine() {
+        let (a, b) = ab();
+        let f = Term::free("f", Type::fun(a.clone(), b.clone()));
+        let thm = id_left(&f).unwrap();
+        assert!(thm.hyps().is_empty() && thm.has_no_obs());
+        let lhs = comp(&id(b), &f).unwrap();
+        assert_eq!(thm.concl(), &lhs.equals(f).unwrap());
+    }
+
+    #[test]
+    fn id_right_is_genuine() {
+        let (a, b) = ab();
+        let f = Term::free("f", Type::fun(a.clone(), b));
+        let thm = id_right(&f).unwrap();
+        assert!(thm.hyps().is_empty() && thm.has_no_obs());
+        let lhs = comp(&f, &id(a)).unwrap();
+        assert_eq!(thm.concl(), &lhs.equals(f).unwrap());
+    }
+
+    #[test]
+    fn comp_assoc_is_genuine() {
+        let a = Type::tfree("a");
+        let b = Type::tfree("b");
+        let c = Type::tfree("c");
+        let d = Type::tfree("d");
+        let f = Term::free("f", Type::fun(a.clone(), b.clone()));
+        let g = Term::free("g", Type::fun(b.clone(), c.clone()));
+        let h = Term::free("h", Type::fun(c, d));
+        let thm = comp_assoc(&h, &g, &f).unwrap();
+        assert!(thm.hyps().is_empty() && thm.has_no_obs());
+        let lhs = comp(&comp(&h, &g).unwrap(), &f).unwrap();
+        let rhs = comp(&h, &comp(&g, &f).unwrap()).unwrap();
+        assert_eq!(thm.concl(), &lhs.equals(rhs).unwrap());
+    }
+
+    #[test]
+    fn comp_cong_whiskers_both_sides() {
+        let a = Type::tfree("a");
+        let b = Type::tfree("b");
+        let c = Type::tfree("c");
+        let f = Term::free("f", Type::fun(a.clone(), b.clone()));
+        let g = Term::free("g", Type::fun(b, c));
+        let f_eq = Thm::refl(f.clone()).unwrap();
+        let g_eq = Thm::refl(g.clone()).unwrap();
+        let thm = comp_cong(&g_eq, &f_eq).unwrap();
+        let expected = comp(&g, &f).unwrap();
+        assert_eq!(thm.concl(), &expected.clone().equals(expected).unwrap());
+    }
+}

--- a/crates/covalence-hol/src/init/coprod.rs
+++ b/crates/covalence-hol/src/init/coprod.rs
@@ -10,14 +10,20 @@
 //! predicate discharged) and disjointness go through unconditionally.
 //!
 //! This is the foundation under [`init::option`](crate::init::option).
-//! The `coprodCase` computation equations build on the round-trips here
-//! (still to come).
+//!
+//! On top of the round-trips this module now proves the full coproduct
+//! **universal property**: the `coprod_case` computation equations
+//! [`case_inl`] / [`case_inr`] (`[f,g] ∘ inl = f` pointwise), injection
+//! **surjectivity** [`cases`] (every value is `inl` or `inr`), and the
+//! **η / fusion** law [`case_eta`] (`m = [m ∘ inl, m ∘ inr]`). Together
+//! with [`init::cat`](crate::init::cat) these are the axioms the
+//! point-free [`monoidal`](crate::monoidal) API reasons through.
 
 use covalence_core::{Error, Result, Term, Thm, Type};
 
 use crate::init::eq::delta_head;
 use crate::init::ext::{TermExt, ThmExt};
-use crate::init::logic::{exists_intro, simp, truth};
+use crate::init::logic::{exists_elim, exists_intro, simp, truth};
 
 pub use covalence_core::defs::{coprod, coprod_case, inl, inr};
 
@@ -137,8 +143,497 @@ pub fn inl_ne_inr(a: &Type, b: &Type, av: &Term, bv: &Term) -> Result<Thm> {
 }
 
 // ============================================================================
+// Injection round-trips on `rep`, relation injectivity / disjointness.
+//
+// The pieces the coprod **universal property** (`coprod_case` β below)
+// needs: `rep (inj v) = injRel v`, the injection relations are injective
+// (`leftRel a = leftRel a' ⟹ a = a'`), and the two relation families are
+// disjoint (`¬(leftRel a = rightRel b)`).
+// ============================================================================
+
+/// `⊢ rep (inl av) = leftRel av` — the left injection's representative.
+fn rep_inl(a: &Type, b: &Type, av: &Term) -> Result<Thm> {
+    let (inl_u, lrel) = inl_unfold(a, b, av)?; // ⊢ inl av = abs LR
+    inl_u
+        .cong_arg(rep_c(a, b))? // ⊢ rep (inl av) = rep (abs LR)
+        .trans(round_trip(a, b, &lrel, av, true)?) // ⊢ rep (abs LR) = LR
+}
+
+/// `⊢ rep (inr bv) = rightRel bv` — the right injection's representative.
+fn rep_inr(a: &Type, b: &Type, bv: &Term) -> Result<Thm> {
+    let (inr_u, rrel) = inr_unfold(a, b, bv)?;
+    inr_u
+        .cong_arg(rep_c(a, b))?
+        .trans(round_trip(a, b, &rrel, bv, false)?)
+}
+
+/// `⊢ ¬(leftRel av = rightRel bv)` — the two injection relations never
+/// agree (the discriminator `z` forces `T` on the left, `F` on the
+/// right). This is the relation-level core of [`inl_ne_inr`].
+fn left_ne_right(a: &Type, b: &Type, av: &Term, bv: &Term) -> Result<Thm> {
+    let lrel = inl_unfold(a, b, av)?.1;
+    let rrel = inr_unfold(a, b, bv)?.1;
+    let eq = lrel.clone().equals(rrel.clone())?;
+    let h = Thm::assume(eq.clone())?;
+    // Apply both sides to (av, bv, T) and βι-reduce.
+    let tt = Term::bool_lit(true);
+    let applied = h
+        .cong_fn(av.clone())?
+        .cong_fn(bv.clone())?
+        .cong_fn(tt)?
+        .reduce_lhs()?
+        .reduce_rhs()?; // {H} ⊢ (T ∧ av=av) = (¬T ∧ bv=bv)
+    let av_t = Thm::refl(av.clone())?.eqt_intro()?;
+    let bv_t = Thm::refl(bv.clone())?.eqt_intro()?;
+    let applied = applied.rewrite(&av_t)?.rewrite(&bv_t)?; // {H} ⊢ (T ∧ T) = (¬T ∧ T)
+    let (lhs, rhs) = {
+        let (l, r) = applied.concl().as_eq().ok_or(Error::NotAnEquation)?;
+        (l.clone(), r.clone())
+    };
+    let t_eq_f = simp(&lhs)?.sym()?.trans(applied)?.trans(simp(&rhs)?)?; // {H} ⊢ T = F
+    let f = t_eq_f.eq_mp(truth())?; // {H} ⊢ F
+    f.imp_intro(&eq)?.not_intro()
+}
+
+/// `⊢ injRel v = injRel v2 ⟹ v = v2` — injectivity of a tagged
+/// injection relation. `x` / `y` are the two carrier slots and `z` the
+/// discriminator to probe at: for `leftRel` use `(x = v, y arbitrary,
+/// z = T)`, for `rightRel` use `(x arbitrary, y = v, z = F)`. At those
+/// slots both sides reduce to `z' ∧ (v = v[2])`; folding `v = v` to `T`
+/// and discharging the (true) discriminator leaves `v = v2`.
+fn rel_inj(rel: &Term, rel2: &Term, v: &Term, v2: &Term, x: &Term, y: &Term, z: bool) -> Result<Thm> {
+    let eq = rel.clone().equals(rel2.clone())?;
+    let h = Thm::assume(eq.clone())?;
+    let applied = h
+        .cong_fn(x.clone())?
+        .cong_fn(y.clone())?
+        .cong_fn(Term::bool_lit(z))?
+        .reduce_lhs()?
+        .reduce_rhs()?; // {H} ⊢ (z' ∧ (v = v)) = (z' ∧ (v = v2))
+    // Fold `v = v` to `T` (simp leaves carrier equalities), then let `simp`
+    // collapse the discriminator and `T ∧ _`.
+    let vv_t = Thm::refl(v.clone())?.eqt_intro()?; // ⊢ (v=v) = T
+    let applied = applied.rewrite(&vv_t)?; // {H} ⊢ (z' ∧ T) = (z' ∧ (v = v2))
+    let (lhs, rhs) = {
+        let (l, r) = applied.concl().as_eq().ok_or(Error::NotAnEquation)?;
+        (l.clone(), r.clone())
+    };
+    let v_eq = simp(&lhs)? // ⊢ (z' ∧ T) = T
+        .sym()?
+        .trans(applied)? // {H} ⊢ T = (z' ∧ (v = v2))
+        .trans(simp(&rhs)?)? // {H} ⊢ T = (v = v2)
+        .sym()?
+        .eqt_elim()?; // {H} ⊢ v = v2
+    let _ = v2; // documentary: v2 enters via `rel2`, not directly
+    v_eq.imp_intro(&eq)
+}
+
+// ============================================================================
+// The coproduct universal property — `coprod_case` β-equations.
+//
+//   ⊢ coprod_case f g (inl a) = f a        (case_inl)
+//   ⊢ coprod_case f g (inr b) = g b        (case_inr)
+//
+// `coprod_case f g c = ε(λr. (∀a. rep c = leftRel a  ⟹ r = f a)
+//                         ∧ (∀b. rep c = rightRel b ⟹ r = g b))`.
+// At `c = inl a₀`, `rep c = leftRel a₀`: the *left* clause at `a := a₀`
+// (antecedent `refl`) pins `ε = f a₀`, while the right clause is vacuous
+// by disjointness. The witness `f a₀` satisfies the predicate (left clause
+// by `leftRel` injectivity, right clause vacuously), so the choice axiom
+// applies. `inr` is symmetric.
+// ============================================================================
+
+/// `⊢ coprod_case f g (inl av) = f av`. Genuine: hypothesis- and
+/// oracle-free.
+pub fn case_inl(a: &Type, b: &Type, gamma: &Type, f: &Term, g: &Term, av: &Term) -> Result<Thm> {
+    let c = Term::app(inl(a.clone(), b.clone()), av.clone());
+    let (pred, eps_eq) = case_unfold(a, b, gamma, f, g, &c)?;
+    let witness = Term::app(f.clone(), av.clone());
+
+    // ⊢ pred witness — the predicate holds at `f av`.
+    let p_at = pred_at_inl(a, b, f, g, av, &pred, &witness)?;
+    // ⊢ ε pred = f av, from the left clause at `a := av`.
+    let at_choice = Thm::select_ax(pred.clone(), witness.clone())?.imp_elim(p_at)?;
+    let eps = at_choice.concl().as_app().ok_or(Error::NotAnEquation)?.1.clone();
+    let conj = Thm::beta_conv(Term::app(pred.clone(), eps))?.eq_mp(at_choice)?;
+    let left_clause = conj.and_elim_l()?; // ∀a. rep(inl av)=leftRel a ⟹ ε = f a
+    let pinned = left_clause
+        .all_elim(av.clone())? // ⊢ rep(inl av)=leftRel av ⟹ ε = f av
+        .imp_elim(rep_inl(a, b, av)?)?; // ⊢ ε pred = f av
+    eps_eq.trans(pinned)
+}
+
+/// `⊢ coprod_case f g (inr bv) = g bv`. Genuine: hypothesis- and
+/// oracle-free.
+pub fn case_inr(a: &Type, b: &Type, gamma: &Type, f: &Term, g: &Term, bv: &Term) -> Result<Thm> {
+    let c = Term::app(inr(a.clone(), b.clone()), bv.clone());
+    let (pred, eps_eq) = case_unfold(a, b, gamma, f, g, &c)?;
+    let witness = Term::app(g.clone(), bv.clone());
+
+    let p_at = pred_at_inr(a, b, f, g, bv, &pred, &witness)?;
+    let at_choice = Thm::select_ax(pred.clone(), witness.clone())?.imp_elim(p_at)?;
+    let eps = at_choice.concl().as_app().ok_or(Error::NotAnEquation)?.1.clone();
+    let conj = Thm::beta_conv(Term::app(pred.clone(), eps))?.eq_mp(at_choice)?;
+    let right_clause = conj.and_elim_r()?; // ∀b. rep(inr bv)=rightRel b ⟹ ε = g b
+    let pinned = right_clause
+        .all_elim(bv.clone())?
+        .imp_elim(rep_inr(a, b, bv)?)?; // ⊢ ε pred = g bv
+    eps_eq.trans(pinned)
+}
+
+/// δ-unfold `coprod_case f g c` to its choice term `ε pred`, returning
+/// `(pred, ⊢ coprod_case f g c = ε pred)`.
+fn case_unfold(
+    a: &Type,
+    b: &Type,
+    gamma: &Type,
+    f: &Term,
+    g: &Term,
+    c: &Term,
+) -> Result<(Term, Thm)> {
+    let cc = coprod_case(a.clone(), b.clone(), gamma.clone())
+        .apply(f.clone())?
+        .apply(g.clone())?
+        .apply(c.clone())?;
+    // Unfold only the *head* `coprod_case` — `delta_all` would also unfold
+    // any `coprod_case` nested inside `f` / `g` / `c` (e.g. when they are
+    // themselves copairings, as the monoidal structure morphisms are).
+    let unfold = delta_head(&cc)?.rhs_conv(|t| t.reduce())?; // ⊢ cc = ε pred
+    let eps = rhs_of(&unfold)?;
+    let pred = eps.as_app().ok_or(Error::NotAnEquation)?.1.clone();
+    Ok((pred, unfold))
+}
+
+/// `⊢ pred (f av)` for `c = inl av`: the left clause holds by `leftRel`
+/// injectivity (`leftRel av = leftRel a ⟹ av = a ⟹ f av = f a`), the
+/// right clause vacuously by disjointness.
+fn pred_at_inl(
+    a: &Type,
+    b: &Type,
+    f: &Term,
+    g: &Term,
+    av: &Term,
+    pred: &Term,
+    witness: &Term,
+) -> Result<Thm> {
+    let rep_eq = rep_inl(a, b, av)?; // ⊢ rep(inl av) = leftRel av
+
+    // Left clause: ∀a. rep(inl av) = leftRel a ⟹ f av = f a.
+    let a_var = Term::free("__cia", a.clone());
+    let lrel_a = inl_unfold(a, b, &a_var)?.1;
+    let ante_l = lhs_of(&rep_eq)?.equals(lrel_a.clone())?; // rep(inl av) = leftRel __cia
+    let hl = Thm::assume(ante_l.clone())?;
+    let rels_eq = rep_eq.clone().sym()?.trans(hl)?; // {H} ⊢ leftRel av = leftRel __cia
+    let probe_y = Term::free("__ciy", b.clone());
+    let inj = rel_inj(&lrel_of(a, b, av)?, &lrel_a, av, &a_var, av, &probe_y, true)?;
+    let v_eq = inj.imp_elim(rels_eq)?; // {H} ⊢ av = __cia
+    let f_cong = Thm::refl(f.clone())?.cong_app(v_eq)?; // {H} ⊢ f av = f __cia
+    let left_clause = f_cong.imp_intro(&ante_l)?.all_intro("__cia", a.clone())?;
+
+    // Right clause: ∀b. rep(inl av) = rightRel b ⟹ f av = g b (vacuous).
+    let b_var = Term::free("__cib", b.clone());
+    let rrel_b = inr_unfold(a, b, &b_var)?.1;
+    let ante_r = lhs_of(&rep_eq)?.equals(rrel_b.clone())?;
+    let hr = Thm::assume(ante_r.clone())?;
+    let bad = rep_eq.sym()?.trans(hr)?; // {H} ⊢ leftRel av = rightRel __cib
+    let f_false = left_ne_right(a, b, av, &b_var)?.not_elim(bad)?; // {H} ⊢ F
+    let goal = witness.clone().equals(Term::app(g.clone(), b_var))?;
+    let right_clause = f_false.false_elim(goal)?.imp_intro(&ante_r)?.all_intro("__cib", b.clone())?;
+
+    let conj = left_clause.and_intro(right_clause)?;
+    Thm::beta_conv(Term::app(pred.clone(), witness.clone()))?
+        .sym()?
+        .eq_mp(conj)
+}
+
+/// `⊢ pred (g bv)` for `c = inr bv`: symmetric to [`pred_at_inl`].
+fn pred_at_inr(
+    a: &Type,
+    b: &Type,
+    f: &Term,
+    g: &Term,
+    bv: &Term,
+    pred: &Term,
+    witness: &Term,
+) -> Result<Thm> {
+    let rep_eq = rep_inr(a, b, bv)?; // ⊢ rep(inr bv) = rightRel bv
+
+    // Left clause: ∀a. rep(inr bv) = leftRel a ⟹ g bv = f a (vacuous).
+    let a_var = Term::free("__cia", a.clone());
+    let lrel_a = inl_unfold(a, b, &a_var)?.1;
+    let ante_l = lhs_of(&rep_eq)?.equals(lrel_a.clone())?;
+    let hl = Thm::assume(ante_l.clone())?;
+    let bad = rep_eq.clone().sym()?.trans(hl)?; // {H} ⊢ rightRel bv = leftRel __cia
+    let f_false = left_ne_right(a, b, &a_var, bv)?.not_elim(bad.sym()?)?; // {H} ⊢ F
+    let goal = witness.clone().equals(Term::app(f.clone(), a_var))?;
+    let left_clause = f_false.false_elim(goal)?.imp_intro(&ante_l)?.all_intro("__cia", a.clone())?;
+
+    // Right clause: ∀b. rep(inr bv) = rightRel b ⟹ g bv = g b.
+    let b_var = Term::free("__cib", b.clone());
+    let rrel_b = inr_unfold(a, b, &b_var)?.1;
+    let ante_r = lhs_of(&rep_eq)?.equals(rrel_b.clone())?;
+    let hr = Thm::assume(ante_r.clone())?;
+    let rels_eq = rep_eq.sym()?.trans(hr)?; // {H} ⊢ rightRel bv = rightRel __cib
+    let probe_x = Term::free("__cix", a.clone());
+    let inj = rel_inj(
+        &rrel_of(a, b, bv)?,
+        &rrel_b,
+        bv,
+        &b_var,
+        &probe_x,
+        bv,
+        false,
+    )?; // ⊢ (rightRel bv = rightRel __cib) ⟹ bv = __cib
+    let v_eq = inj.imp_elim(rels_eq)?; // {H} ⊢ bv = __cib
+    let g_cong = Thm::refl(g.clone())?.cong_app(v_eq)?; // {H} ⊢ g bv = g __cib
+    let right_clause = g_cong.imp_intro(&ante_r)?.all_intro("__cib", b.clone())?;
+
+    let conj = left_clause.and_intro(right_clause)?;
+    Thm::beta_conv(Term::app(pred.clone(), witness.clone()))?
+        .sym()?
+        .eq_mp(conj)
+}
+
+/// The reduced left/right injection relations at a carrier value.
+fn lrel_of(a: &Type, b: &Type, av: &Term) -> Result<Term> {
+    Ok(inl_unfold(a, b, av)?.1)
+}
+fn rrel_of(a: &Type, b: &Type, bv: &Term) -> Result<Term> {
+    Ok(inr_unfold(a, b, bv)?.1)
+}
+
+// ============================================================================
+// Surjectivity of the injections + the η / fusion law.
+//
+// `coprod` is *covered* by its two injections: every `c : coprod α β` is
+// `inl x` or `inr y`. That follows from the subtype interface — `c =
+// abs (rep c)` and `rep c` satisfies the carving predicate `(∃a. rep c =
+// leftRel a) ∨ (∃b. rep c = rightRel b)` — mapped through `abs`. Together
+// with the β-equations it gives the **uniqueness / η** law: a map out of
+// `coprod` is determined by its two restrictions, so
+// `m = [m ∘ inl, m ∘ inr]`. This is the workhorse for *proving* point-free
+// equations between maps out of a coproduct.
+// ============================================================================
+
+/// `⊢ (∃x. c = inl x) ∨ (∃y. c = inr y)` — every `coprod α β` value is an
+/// injection. Genuine: hypothesis- and oracle-free.
+pub fn cases(a: &Type, b: &Type, c: &Term) -> Result<Thm> {
+    let repc = Term::app(rep_c(a, b), c.clone());
+    // c = abs(rep c) and rep(abs(rep c)) = rep c.
+    let abs_rep = Thm::spec_abs_rep(coprod_spec(), vec![a.clone(), b.clone()], c.clone())?;
+    let rep_abs_rep = abs_rep.clone().cong_arg(rep_c(a, b))?;
+    // ⊢ P(rep c) ∨ ¬∃R. P R  (the witness-free subtype back-direction).
+    let back = Thm::spec_rep_abs_back(coprod_spec(), vec![a.clone(), b.clone()], repc.clone())?;
+    let disj0 = back.imp_elim(rep_abs_rep)?;
+    let (p_repc, not_ex) =
+        parse_or(disj0.concl()).ok_or_else(|| Error::ConnectiveRule("cases: not a ∨".into()))?;
+    let pred_p = p_repc.as_app().ok_or(Error::NotAnEquation)?.0.clone(); // P
+
+    // The predicate is inhabited (by `leftRel` of a fresh carrier), so the
+    // empty-predicate escape disjunct `¬∃R. P R` is refutable. The `∃`
+    // there is over `λR. P R` (η-expanded), so extract that exact body.
+    let ex_term = not_ex.as_app().ok_or(Error::NotAnEquation)?.1.clone(); // ∃R. (λR. P R) R
+    let pred_ex = ex_term.as_app().ok_or(Error::NotAnEquation)?.1.clone(); // λR. P R
+    let ex_p = pred_nonempty(a, b, &pred_p, &pred_ex)?;
+    let left = Thm::assume(p_repc.clone())?.imp_intro(&p_repc)?;
+    let right = Thm::assume(not_ex.clone())?
+        .not_elim(ex_p)?
+        .false_elim(p_repc.clone())?
+        .imp_intro(&not_ex)?;
+    let p_rep = disj0.or_elim(left, right)?; // ⊢ P(rep c)
+
+    // β: ⊢ (∃a. rep c = leftRel a) ∨ (∃b. rep c = rightRel b).
+    let inner = Thm::beta_conv(Term::app(pred_p, repc))?.eq_mp(p_rep)?;
+    let (ex_lrel, ex_rrel) =
+        parse_or(inner.concl()).ok_or_else(|| Error::ConnectiveRule("cases: inner ∨".into()))?;
+
+    let (goal_l, goal_r) = cases_goal(a, b, c)?;
+    // Map each representative disjunct to the corresponding injection.
+    let left2 = map_to_inj(a, b, &abs_rep, &ex_lrel, &goal_l, &goal_r, true)?;
+    let right2 = map_to_inj(a, b, &abs_rep, &ex_rrel, &goal_l, &goal_r, false)?;
+    inner.or_elim(left2, right2)
+}
+
+/// `(∃x. c = inl x, ∃y. c = inr y)`.
+fn cases_goal(a: &Type, b: &Type, c: &Term) -> Result<(Term, Term)> {
+    let x = Term::free("__sx", a.clone());
+    let ex_inl = c
+        .clone()
+        .equals(Term::app(inl(a.clone(), b.clone()), x))?
+        .exists("__sx", a.clone())?;
+    let y = Term::free("__sy", b.clone());
+    let ex_inr = c
+        .clone()
+        .equals(Term::app(inr(a.clone(), b.clone()), y))?
+        .exists("__sy", b.clone())?;
+    Ok((ex_inl, ex_inr))
+}
+
+/// `⊢ ∃R. (λR. P R) R` — the coprod carving predicate is inhabited
+/// (witness `leftRel av`). `pred_p` is the bare predicate `P` (for the
+/// inner β-reduct); `pred_ex` is the η-expanded `λR. P R` the `∃` in the
+/// `spec_rep_abs_back` escape disjunct quantifies, so the result matches
+/// it exactly. Sub-predicates are *extracted* from `P`'s β-reduct.
+fn pred_nonempty(a: &Type, b: &Type, pred_p: &Term, pred_ex: &Term) -> Result<Thm> {
+    let av = Term::free("__pne", a.clone());
+    let lr_av = lrel_of(a, b, &av)?;
+    let beta = Thm::beta_conv(Term::app(pred_p.clone(), lr_av.clone()))?; // ⊢ P(leftRel av) = D
+    let d = rhs_of(&beta)?;
+    let (ex_l, ex_r) =
+        parse_or(&d).ok_or_else(|| Error::ConnectiveRule("pred_nonempty: not ∨".into()))?;
+    let pred_l = ex_l.as_app().ok_or(Error::NotAnEquation)?.1.clone(); // λa. leftRel av = leftRel a
+    // ⊢ pred_l av  (β-reduces to leftRel av = leftRel av, refl).
+    let at = Thm::beta_conv(Term::app(pred_l.clone(), av.clone()))?;
+    let pred_l_av = at.sym()?.eq_mp(Thm::refl(lr_av.clone())?)?;
+    let d_thm = exists_intro(pred_l, av, pred_l_av)?.or_intro_l(ex_r)?; // ⊢ D
+    let p_at = beta.sym()?.eq_mp(d_thm)?; // ⊢ P(leftRel av)
+    // Re-wrap through the η-expanded predicate `λR. P R`.
+    let ex_beta = Thm::beta_conv(Term::app(pred_ex.clone(), lr_av.clone()))?; // ⊢ (λR.P R)(leftRel av) = P(leftRel av)
+    let pred_ex_at = ex_beta.sym()?.eq_mp(p_at)?; // ⊢ (λR. P R)(leftRel av)
+    exists_intro(pred_ex.clone(), lr_av, pred_ex_at)
+}
+
+/// `⊢ (∃v. rep c = injRel v) ⟹ ((∃x. c = inl x) ∨ (∃y. c = inr y))`,
+/// the `is_left` arm mapping a representative disjunct to its injection.
+fn map_to_inj(
+    a: &Type,
+    b: &Type,
+    abs_rep: &Thm,
+    ex_rel: &Term,
+    goal_l: &Term,
+    goal_r: &Term,
+    is_left: bool,
+) -> Result<Thm> {
+    let pred = ex_rel.as_app().ok_or(Error::NotAnEquation)?.1.clone(); // λv. rep c = injRel v
+    let carrier = if is_left { a } else { b };
+    let v = Term::free("__mtv", carrier.clone());
+    let ante_app = Term::app(pred.clone(), v.clone());
+    // ⊢ rep c = injRel v, from the assumed `pred v`.
+    let ante_beta = Thm::beta_conv(ante_app.clone())?; // ⊢ pred v = (rep c = injRel v)
+    let h = ante_beta.clone().eq_mp(Thm::assume(ante_app.clone())?)?;
+    // c = inj v: cong `abs`, then abs_rep on the left, inj round-trip on the right.
+    let abs = Term::spec_abs(coprod_spec(), vec![a.clone(), b.clone()]);
+    let inj_unfold = if is_left {
+        inl_unfold(a, b, &v)?.0 // ⊢ inl v = abs(leftRel v)
+    } else {
+        inr_unfold(a, b, &v)?.0
+    };
+    let c_eq_inj = abs_rep
+        .clone()
+        .sym()? // ⊢ c = abs(rep c)
+        .trans(h.cong_arg(abs)?)? // ⊢ c = abs(injRel v)
+        .trans(inj_unfold.sym()?)?; // ⊢ c = inj v
+    // ∃-introduce, then inject into the goal disjunction.
+    let goal = if is_left { goal_l } else { goal_r };
+    let goal_pred = goal.as_app().ok_or(Error::NotAnEquation)?.1.clone();
+    let intro_beta = Thm::beta_conv(Term::app(goal_pred.clone(), v.clone()))?; // ⊢ goal_pred v = (c = inj v)
+    let at = intro_beta.sym()?.eq_mp(c_eq_inj)?; // ⊢ goal_pred v
+    let ex = exists_intro(goal_pred, v.clone(), at)?; // ⊢ ∃. c = inj _
+    let full = if is_left {
+        ex.or_intro_l(goal_r.clone())?
+    } else {
+        ex.or_intro_r(goal_l.clone())?
+    };
+    // ⊢ ∀v. pred v ⟹ goal, then close the existential.
+    let step = full.imp_intro(&ante_app)?.all_intro("__mtv", carrier.clone())?;
+    let branch = exists_elim(Thm::assume(ex_rel.clone())?, full_goal(goal_l, goal_r)?, step)?;
+    branch.imp_intro(ex_rel)
+}
+
+/// `(∃x. c = inl x) ∨ (∃y. c = inr y)`.
+fn full_goal(goal_l: &Term, goal_r: &Term) -> Result<Term> {
+    goal_l.clone().or(goal_r.clone())
+}
+
+/// `⊢ m = coprod_case (m ∘ inl) (m ∘ inr)` — the coproduct **η / fusion**
+/// law: a map out of `coprod α β` equals the copairing of its
+/// restrictions. `m : coprod α β → γ`. Genuine: hypothesis- and
+/// oracle-free.
+pub fn case_eta(a: &Type, b: &Type, gamma: &Type, m: &Term) -> Result<Thm> {
+    use crate::init::cat::comp;
+    let inl_t = inl(a.clone(), b.clone());
+    let inr_t = inr(a.clone(), b.clone());
+    let m_inl = comp(m, &inl_t)?; // m ∘ inl : α → γ
+    let m_inr = comp(m, &inr_t)?; // m ∘ inr : β → γ
+    let k = coprod_case(a.clone(), b.clone(), gamma.clone())
+        .apply(m_inl.clone())?
+        .apply(m_inr.clone())?; // [m∘inl, m∘inr]
+
+    // Extensionality at a fresh point `c`, by cases on `c`.
+    let c = Term::free("__etc", coprod(a.clone(), b.clone()));
+    let point = case_eta_point(a, b, gamma, m, &m_inl, &m_inr, &k, &c)?; // ⊢ m c = k c
+
+    // ⊢ m = k via abs + η on both sides.
+    crate::init::cat::fun_ext(point, "__etc", &coprod(a.clone(), b.clone()))
+}
+
+/// `⊢ m c = k c` for `k = [m∘inl, m∘inr]`, by case analysis on `c`.
+#[allow(clippy::too_many_arguments)]
+fn case_eta_point(
+    a: &Type,
+    b: &Type,
+    gamma: &Type,
+    m: &Term,
+    m_inl: &Term,
+    m_inr: &Term,
+    k: &Term,
+    c: &Term,
+) -> Result<Thm> {
+    let goal = Term::app(m.clone(), c.clone()).equals(Term::app(k.clone(), c.clone()))?;
+    let (ex_inl, ex_inr) = cases_goal(a, b, c)?;
+    let cases_thm = cases(a, b, c)?;
+    let left = eta_branch(a, b, gamma, m, m_inl, k, &ex_inl, &goal, true)?;
+    let right = eta_branch(a, b, gamma, m, m_inr, k, &ex_inr, &goal, false)?;
+    cases_thm.or_elim(left, right)
+}
+
+/// `⊢ (∃v. c = inj v) ⟹ (m c = k c)` on one injection arm.
+#[allow(clippy::too_many_arguments)]
+fn eta_branch(
+    a: &Type,
+    b: &Type,
+    gamma: &Type,
+    m: &Term,
+    m_inj: &Term,
+    k: &Term,
+    ex_inj: &Term,
+    goal: &Term,
+    is_left: bool,
+) -> Result<Thm> {
+    use crate::init::cat::comp;
+    let pred = ex_inj.as_app().ok_or(Error::NotAnEquation)?.1.clone(); // λv. c = inj v
+    let carrier = if is_left { a } else { b };
+    let v = Term::free("__ebv", carrier.clone());
+    let ante_app = Term::app(pred.clone(), v.clone());
+    let h = Thm::beta_conv(ante_app.clone())?.eq_mp(Thm::assume(ante_app.clone())?)?; // ⊢ c = inj v
+
+    // m c = m (inj v).
+    let m_lhs = Thm::refl(m.clone())?.cong_app(h.clone())?; // ⊢ m c = m (inj v)
+    // k c = k (inj v) = m_inj v = (m ∘ inj) v = m (inj v).
+    let k_at_inj = if is_left {
+        case_inl(a, b, gamma, &comp(m, &inl(a.clone(), b.clone()))?, &comp(m, &inr(a.clone(), b.clone()))?, &v)?
+    } else {
+        case_inr(a, b, gamma, &comp(m, &inl(a.clone(), b.clone()))?, &comp(m, &inr(a.clone(), b.clone()))?, &v)?
+    }; // ⊢ k (inj v) = (m ∘ inj) v
+    let mij_reduce = crate::init::cat::comp_beta(m_inj, &v)?; // ⊢ (m ∘ inj) v = m (inj v)
+    let k_rhs = Thm::refl(k.clone())?
+        .cong_app(h)? // ⊢ k c = k (inj v)
+        .trans(k_at_inj)? // ⊢ k c = (m ∘ inj) v
+        .trans(mij_reduce)?; // ⊢ k c = m (inj v)
+    let point = m_lhs.trans(k_rhs.sym()?)?; // ⊢ m c = k c
+    // ⊢ ∀v. pred v ⟹ (m c = k c), then exists-eliminate the witness.
+    let step = point.imp_intro(&ante_app)?.all_intro("__ebv", carrier.clone())?;
+    let branch = exists_elim(Thm::assume(ex_inj.clone())?, goal.clone(), step)?;
+    branch.imp_intro(ex_inj)
+}
+
+// ============================================================================
 // Helpers.
 // ============================================================================
+
+fn lhs_of(thm: &Thm) -> Result<Term> {
+    Ok(thm.concl().as_eq().ok_or(Error::NotAnEquation)?.0.clone())
+}
 
 fn rhs_of(thm: &Thm) -> Result<Term> {
     Ok(thm.concl().as_eq().ok_or(Error::NotAnEquation)?.1.clone())
@@ -179,5 +674,75 @@ mod tests {
         let av = Term::free("av", a.clone());
         let bv = Term::free("bv", b.clone());
         assert!(inl_ne_inr(&a, &b, &av, &bv).unwrap().hyps().is_empty());
+    }
+
+    fn abc() -> (Type, Type, Type) {
+        (Type::tfree("a"), Type::tfree("b"), Type::tfree("c"))
+    }
+
+    #[test]
+    fn case_inl_computes() {
+        // ⊢ coprod_case f g (inl av) = f av — the left β-equation.
+        let (a, b, c) = abc();
+        let f = Term::free("f", Type::fun(a.clone(), c.clone()));
+        let g = Term::free("g", Type::fun(b.clone(), c.clone()));
+        let av = Term::free("av", a.clone());
+        let thm = case_inl(&a, &b, &c, &f, &g, &av).unwrap();
+        assert!(thm.hyps().is_empty(), "case_inl is proved, not postulated");
+        assert!(thm.has_no_obs(), "case_inl is oracle-free");
+        let lhs = coprod_case(a, b, c)
+            .apply(f.clone())
+            .unwrap()
+            .apply(g)
+            .unwrap()
+            .apply(Term::app(inl(av.type_of().unwrap(), Type::tfree("b")), av.clone()))
+            .unwrap();
+        assert_eq!(thm.concl(), &lhs.equals(Term::app(f, av)).unwrap());
+    }
+
+    #[test]
+    fn case_inr_computes() {
+        // ⊢ coprod_case f g (inr bv) = g bv — the right β-equation.
+        let (a, b, c) = abc();
+        let f = Term::free("f", Type::fun(a.clone(), c.clone()));
+        let g = Term::free("g", Type::fun(b.clone(), c.clone()));
+        let bv = Term::free("bv", b.clone());
+        let thm = case_inr(&a, &b, &c, &f, &g, &bv).unwrap();
+        assert!(thm.hyps().is_empty() && thm.has_no_obs());
+        assert_eq!(rhs_of(&thm).unwrap(), Term::app(g, bv));
+    }
+
+    #[test]
+    fn cases_covers_both_injections() {
+        let (a, b, _c) = abc();
+        let c = Term::free("c", coprod(a.clone(), b.clone()));
+        let thm = cases(&a, &b, &c).unwrap();
+        assert!(thm.hyps().is_empty() && thm.has_no_obs());
+        let (ex_l, ex_r) = cases_goal(&a, &b, &c).unwrap();
+        assert_eq!(thm.concl(), &ex_l.or(ex_r).unwrap());
+    }
+
+    #[test]
+    fn case_eta_fuses_restrictions() {
+        // ⊢ m = coprod_case (m∘inl) (m∘inr).
+        let (a, b, g) = abc();
+        let m = Term::free("m", Type::fun(coprod(a.clone(), b.clone()), g.clone()));
+        let thm = case_eta(&a, &b, &g, &m).unwrap();
+        assert!(thm.hyps().is_empty(), "η/fusion is proved, not postulated");
+        assert!(thm.has_no_obs());
+        // LHS is `m`.
+        assert_eq!(thm.concl().as_eq().unwrap().0, &m);
+    }
+
+    #[test]
+    fn case_inl_at_unit() {
+        // The singleton-carrier case the old untagged encoding mishandled.
+        let u = Type::unit();
+        let f = Term::free("f", Type::fun(u.clone(), u.clone()));
+        let g = Term::free("g", Type::fun(u.clone(), u.clone()));
+        let av = Term::free("av", u.clone());
+        let thm = case_inl(&u, &u, &u, &f, &g, &av).unwrap();
+        assert!(thm.hyps().is_empty());
+        assert_eq!(rhs_of(&thm).unwrap(), Term::app(f, av));
     }
 }

--- a/crates/covalence-hol/src/init/coprod.rs
+++ b/crates/covalence-hol/src/init/coprod.rs
@@ -195,13 +195,14 @@ fn left_ne_right(a: &Type, b: &Type, av: &Term, bv: &Term) -> Result<Thm> {
     f.imp_intro(&eq)?.not_intro()
 }
 
-/// `⊢ injRel v = injRel v2 ⟹ v = v2` — injectivity of a tagged
-/// injection relation. `x` / `y` are the two carrier slots and `z` the
-/// discriminator to probe at: for `leftRel` use `(x = v, y arbitrary,
-/// z = T)`, for `rightRel` use `(x arbitrary, y = v, z = F)`. At those
-/// slots both sides reduce to `z' ∧ (v = v[2])`; folding `v = v` to `T`
-/// and discharging the (true) discriminator leaves `v = v2`.
-fn rel_inj(rel: &Term, rel2: &Term, v: &Term, v2: &Term, x: &Term, y: &Term, z: bool) -> Result<Thm> {
+/// `⊢ injRel v = injRel v2 ⟹ v = v2` — injectivity of a tagged injection
+/// relation (here `injRel v2` is `rel2`). `x` / `y` are the two carrier
+/// slots and `z` the discriminator to probe at: for `leftRel` use
+/// `(x = v, y arbitrary, z = T)`, for `rightRel` use `(x arbitrary,
+/// y = v, z = F)`. At those slots both sides reduce to `z' ∧ (v = v[2])`;
+/// folding `v = v` to `T` and discharging the (true) discriminator leaves
+/// `v = v2`.
+fn rel_inj(rel: &Term, rel2: &Term, v: &Term, x: &Term, y: &Term, z: bool) -> Result<Thm> {
     let eq = rel.clone().equals(rel2.clone())?;
     let h = Thm::assume(eq.clone())?;
     let applied = h
@@ -224,7 +225,6 @@ fn rel_inj(rel: &Term, rel2: &Term, v: &Term, v2: &Term, x: &Term, y: &Term, z: 
         .trans(simp(&rhs)?)? // {H} ⊢ T = (v = v2)
         .sym()?
         .eqt_elim()?; // {H} ⊢ v = v2
-    let _ = v2; // documentary: v2 enters via `rel2`, not directly
     v_eq.imp_intro(&eq)
 }
 
@@ -325,7 +325,7 @@ fn pred_at_inl(
     let hl = Thm::assume(ante_l.clone())?;
     let rels_eq = rep_eq.clone().sym()?.trans(hl)?; // {H} ⊢ leftRel av = leftRel __cia
     let probe_y = Term::free("__ciy", b.clone());
-    let inj = rel_inj(&lrel_of(a, b, av)?, &lrel_a, av, &a_var, av, &probe_y, true)?;
+    let inj = rel_inj(&lrel_of(a, b, av)?, &lrel_a, av, av, &probe_y, true)?;
     let v_eq = inj.imp_elim(rels_eq)?; // {H} ⊢ av = __cia
     let f_cong = Thm::refl(f.clone())?.cong_app(v_eq)?; // {H} ⊢ f av = f __cia
     let left_clause = f_cong.imp_intro(&ante_l)?.all_intro("__cia", a.clone())?;
@@ -375,15 +375,8 @@ fn pred_at_inr(
     let hr = Thm::assume(ante_r.clone())?;
     let rels_eq = rep_eq.sym()?.trans(hr)?; // {H} ⊢ rightRel bv = rightRel __cib
     let probe_x = Term::free("__cix", a.clone());
-    let inj = rel_inj(
-        &rrel_of(a, b, bv)?,
-        &rrel_b,
-        bv,
-        &b_var,
-        &probe_x,
-        bv,
-        false,
-    )?; // ⊢ (rightRel bv = rightRel __cib) ⟹ bv = __cib
+    let inj = rel_inj(&rrel_of(a, b, bv)?, &rrel_b, bv, &probe_x, bv, false)?;
+    // ⊢ (rightRel bv = rightRel __cib) ⟹ bv = __cib
     let v_eq = inj.imp_elim(rels_eq)?; // {H} ⊢ bv = __cib
     let g_cong = Thm::refl(g.clone())?.cong_app(v_eq)?; // {H} ⊢ g bv = g __cib
     let right_clause = g_cong.imp_intro(&ante_r)?.all_intro("__cib", b.clone())?;
@@ -582,27 +575,28 @@ fn case_eta_point(
     let goal = Term::app(m.clone(), c.clone()).equals(Term::app(k.clone(), c.clone()))?;
     let (ex_inl, ex_inr) = cases_goal(a, b, c)?;
     let cases_thm = cases(a, b, c)?;
-    let left = eta_branch(a, b, gamma, m, m_inl, k, &ex_inl, &goal, true)?;
-    let right = eta_branch(a, b, gamma, m, m_inr, k, &ex_inr, &goal, false)?;
+    let left = eta_branch(a, b, gamma, m, m_inl, m_inr, k, &ex_inl, &goal, true)?;
+    let right = eta_branch(a, b, gamma, m, m_inl, m_inr, k, &ex_inr, &goal, false)?;
     cases_thm.or_elim(left, right)
 }
 
-/// `⊢ (∃v. c = inj v) ⟹ (m c = k c)` on one injection arm.
+/// `⊢ (∃v. c = inj v) ⟹ (m c = k c)` on one injection arm, where
+/// `k = [m_inl, m_inr]`.
 #[allow(clippy::too_many_arguments)]
 fn eta_branch(
     a: &Type,
     b: &Type,
     gamma: &Type,
     m: &Term,
-    m_inj: &Term,
+    m_inl: &Term,
+    m_inr: &Term,
     k: &Term,
     ex_inj: &Term,
     goal: &Term,
     is_left: bool,
 ) -> Result<Thm> {
-    use crate::init::cat::comp;
+    let (carrier, m_inj) = if is_left { (a, m_inl) } else { (b, m_inr) };
     let pred = ex_inj.as_app().ok_or(Error::NotAnEquation)?.1.clone(); // λv. c = inj v
-    let carrier = if is_left { a } else { b };
     let v = Term::free("__ebv", carrier.clone());
     let ante_app = Term::app(pred.clone(), v.clone());
     let h = Thm::beta_conv(ante_app.clone())?.eq_mp(Thm::assume(ante_app.clone())?)?; // ⊢ c = inj v
@@ -611,9 +605,9 @@ fn eta_branch(
     let m_lhs = Thm::refl(m.clone())?.cong_app(h.clone())?; // ⊢ m c = m (inj v)
     // k c = k (inj v) = m_inj v = (m ∘ inj) v = m (inj v).
     let k_at_inj = if is_left {
-        case_inl(a, b, gamma, &comp(m, &inl(a.clone(), b.clone()))?, &comp(m, &inr(a.clone(), b.clone()))?, &v)?
+        case_inl(a, b, gamma, m_inl, m_inr, &v)?
     } else {
-        case_inr(a, b, gamma, &comp(m, &inl(a.clone(), b.clone()))?, &comp(m, &inr(a.clone(), b.clone()))?, &v)?
+        case_inr(a, b, gamma, m_inl, m_inr, &v)?
     }; // ⊢ k (inj v) = (m ∘ inj) v
     let mij_reduce = crate::init::cat::comp_beta(m_inj, &v)?; // ⊢ (m ∘ inj) v = m (inj v)
     let k_rhs = Thm::refl(k.clone())?

--- a/crates/covalence-hol/src/init/mod.rs
+++ b/crates/covalence-hol/src/init/mod.rs
@@ -53,6 +53,7 @@ macro_rules! cached_thm {
     };
 }
 
+pub mod cat;
 pub mod cond;
 pub mod eq;
 pub mod ext;

--- a/crates/covalence-hol/src/lib.rs
+++ b/crates/covalence-hol/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod hash;
 pub mod hol_light_obs;
 pub mod init;
+pub mod monoidal;
 pub mod peano;
 pub mod proofs;
 pub mod sexp;

--- a/crates/covalence-hol/src/monoidal/derived.rs
+++ b/crates/covalence-hol/src/monoidal/derived.rs
@@ -1,0 +1,90 @@
+//! **Derived** point-free theorems — proved generically against the
+//! [`Monoidal`] trait, using *only* its axioms and inference rules.
+//!
+//! This is the payoff of the abstraction: a routine written here runs
+//! against *any* [`Monoidal`] model (the shallow HOL one today, a deep
+//! proof-term one later), and never touches HOL internals. It is the
+//! coproduct analogue of writing generic PA derivations against
+//! [`Peano`](crate::peano::Peano).
+//!
+//! The headline results — [`copair_unique`] (extensionality for maps out
+//! of `⊕`) and [`swap_involution`] (`σ ∘ σ = id`, the symmetry is its own
+//! inverse) — show that the symmetric-monoidal coherence facts follow
+//! from the β/η laws plus the category laws alone.
+
+use crate::monoidal::Monoidal;
+
+type P<M> = Result<<M as Monoidal>::Proof, <M as Monoidal>::Error>;
+
+/// **Extensionality / uniqueness for the copairing.** Given `lhs`, `rhs :
+/// a ⊕ b → c` that agree after pre-composition with each injection —
+/// `on_inl : ⊢ lhs ∘ inl = rhs ∘ inl` and `on_inr : ⊢ lhs ∘ inr = rhs ∘
+/// inr` — conclude `⊢ lhs = rhs`.
+///
+/// This is the most useful *derived* rule: it reduces any equation
+/// between maps out of a coproduct to two equations on the summands.
+/// Proof: fuse both sides (`m = [m∘inl, m∘inr]`) and rewrite the
+/// copairing with the two hypotheses.
+pub fn copair_unique<M: Monoidal>(
+    m: &M,
+    lhs: M::Hom,
+    rhs: M::Hom,
+    on_inl: M::Proof,
+    on_inr: M::Proof,
+) -> P<M> {
+    let fl = m.fusion(lhs)?; // ⊢ lhs = [lhs∘inl, lhs∘inr]
+    let fr = m.fusion(rhs)?; // ⊢ rhs = [rhs∘inl, rhs∘inr]
+    let mid = m.copair_cong(on_inl, on_inr)?; // ⊢ [lhs∘inl,…] = [rhs∘inl,…]
+    m.trans(m.trans(fl, mid)?, m.sym(fr)?)
+}
+
+/// `⊢ σ ∘ inl = inr` — the symmetry sends the left injection to the right
+/// one. (`σ = [inr, inl]`, so this is just the left β-law.)
+pub fn swap_inl<M: Monoidal>(m: &M, a: M::Obj, b: M::Obj) -> P<M> {
+    m.copair_inl(m.inr(b.clone(), a.clone()), m.inl(b, a))
+}
+
+/// `⊢ σ ∘ inr = inl` — the symmetry sends the right injection to the left
+/// one.
+pub fn swap_inr<M: Monoidal>(m: &M, a: M::Obj, b: M::Obj) -> P<M> {
+    m.copair_inr(m.inr(b.clone(), a.clone()), m.inl(b, a))
+}
+
+/// `⊢ ∇ ∘ inl = id` — the codiagonal collapses the left injection.
+/// (`∇ = [id, id]`, so again the left β-law.)
+pub fn codiag_inl<M: Monoidal>(m: &M, a: M::Obj) -> P<M> {
+    m.copair_inl(m.id(a.clone()), m.id(a))
+}
+
+/// **The symmetry is an involution:** `⊢ σ_{b,a} ∘ σ_{a,b} = id_{a⊕b}`.
+///
+/// Proved point-free from the structure alone: by [`copair_unique`] it
+/// suffices to check both injections, and on each the chain
+/// `(σ' ∘ σ) ∘ inl = σ' ∘ (σ ∘ inl) = σ' ∘ inr = inl = id ∘ inl`
+/// is just associativity + the swap β-laws + the left identity.
+pub fn swap_involution<M: Monoidal>(m: &M, a: M::Obj, b: M::Obj) -> P<M> {
+    let swap1 = m.swap(a.clone(), b.clone())?; // a⊕b → b⊕a
+    let swap2 = m.swap(b.clone(), a.clone())?; // b⊕a → a⊕b
+    let comp = m.comp(swap2.clone(), swap1.clone())?; // a⊕b → a⊕b
+    let id = m.id(m.oplus(a.clone(), b.clone()));
+
+    // on_inl: ⊢ (σ'∘σ)∘inl = id∘inl.
+    let on_inl = {
+        let inl_ab = m.inl(a.clone(), b.clone());
+        let assoc = m.assoc(swap2.clone(), swap1.clone(), inl_ab.clone())?;
+        let cong = m.comp_cong(m.refl(swap2.clone())?, swap_inl(m, a.clone(), b.clone())?)?;
+        let s2_inr = swap_inr(m, b.clone(), a.clone())?; // σ'∘inr = inl_ab
+        let chain = m.trans(m.trans(assoc, cong)?, s2_inr)?; // (σ'∘σ)∘inl = inl_ab
+        m.trans(chain, m.sym(m.id_left(inl_ab)?)?)?
+    };
+    // on_inr: ⊢ (σ'∘σ)∘inr = id∘inr.
+    let on_inr = {
+        let inr_ab = m.inr(a.clone(), b.clone());
+        let assoc = m.assoc(swap2.clone(), swap1.clone(), inr_ab.clone())?;
+        let cong = m.comp_cong(m.refl(swap2.clone())?, swap_inr(m, a.clone(), b.clone())?)?;
+        let s2_inl = swap_inl(m, b.clone(), a.clone())?; // σ'∘inl = inr_ab
+        let chain = m.trans(m.trans(assoc, cong)?, s2_inl)?; // (σ'∘σ)∘inr = inr_ab
+        m.trans(chain, m.sym(m.id_left(inr_ab)?)?)?
+    };
+    copair_unique(m, comp, id, on_inl, on_inr)
+}

--- a/crates/covalence-hol/src/monoidal/mod.rs
+++ b/crates/covalence-hol/src/monoidal/mod.rs
@@ -1,0 +1,161 @@
+//! A trait for **pointless (point-free) programming** over the
+//! coproduct's symmetric-monoidal structure.
+//!
+//! [`Monoidal`] is the abstract interface of "doing a categorical,
+//! point-free proof" — generic over three representations, the
+//! associated types [`Obj`](Monoidal::Obj) / [`Hom`](Monoidal::Hom) /
+//! [`Proof`](Monoidal::Proof). It is the coproduct analogue of
+//! [`Peano`](crate::peano::Peano): the same "one API, many models, with a
+//! soundness map between them" shape (the mirror principle).
+//!
+//! ## Three layers: objects, morphisms, equational proofs
+//!
+//! Point-free programming is *equational reasoning about morphisms* in a
+//! category, and the trait keeps those layers visible:
+//!
+//! - **Objects** ([`Obj`](Monoidal::Obj)) — the "types". They carry a
+//!   symmetric-monoidal product [`oplus`](Monoidal::oplus) (`⊕`, the
+//!   coproduct) used to type the structural morphisms.
+//! - **Morphisms** ([`Hom`](Monoidal::Hom)) — the "programs". Built from
+//!   the **category** vocabulary ([`id`](Monoidal::id),
+//!   [`comp`](Monoidal::comp)) and the coproduct's **join morphisms**:
+//!   the coprojections [`inl`](Monoidal::inl) / [`inr`](Monoidal::inr),
+//!   the copairing [`copair`](Monoidal::copair) (`[f,g]`), the bifunctor
+//!   [`bimap`](Monoidal::bimap) (`f ⊕ g`), the symmetry
+//!   [`swap`](Monoidal::swap) (`σ`), and the codiagonal
+//!   [`codiag`](Monoidal::codiag) (`∇ = [id,id]`).
+//! - **Proofs** ([`Proof`](Monoidal::Proof)) — *equations between
+//!   morphisms*. The **axioms** (as proofs) are the category laws
+//!   ([`id_left`](Monoidal::id_left) / [`id_right`](Monoidal::id_right) /
+//!   [`assoc`](Monoidal::assoc)) and the coproduct **universal property**
+//!   ([`copair_inl`](Monoidal::copair_inl) /
+//!   [`copair_inr`](Monoidal::copair_inr) — the β-laws — and
+//!   [`fusion`](Monoidal::fusion) — the η/uniqueness law). The
+//!   **inference rules** are the equational-logic ones
+//!   ([`refl`](Monoidal::refl) / [`sym`](Monoidal::sym) /
+//!   [`trans`](Monoidal::trans)) plus the structural congruences
+//!   ([`comp_cong`](Monoidal::comp_cong) /
+//!   [`copair_cong`](Monoidal::copair_cong)).
+//!
+//! These axioms suffice to *derive* the symmetric-monoidal coherence
+//! facts — swap's involution and naturality, the associator, the
+//! bifunctoriality of `⊕` — with no further appeal to HOL. The
+//! [`derived`] module collects representative worked examples
+//! ([`derived::swap_involution`], [`derived::copair_unique`]), which is
+//! the point of exposing a "high-level API to prove things using just
+//! this structure".
+//!
+//! ## Two implementations, one API (the mirror principle)
+//!
+//! 1. **Shallow** — [`Hol`]: an object *is* a HOL [`Type`], a morphism
+//!    *is* a HOL `α → β` [`Term`], and a proof *is* a HOL
+//!    [`Thm`](covalence_core::Thm) equating two such terms. The axioms
+//!    forward to the genuine, hypothesis-free theorems in
+//!    [`init::cat`](crate::init::cat) and
+//!    [`init::coprod`](crate::init::coprod). This is the model that
+//!    exists today, and every axiom in it is *proved* (no postulates).
+//! 2. **Deep** (future) — a syntactic `PointFreeTerm` / derivation AST,
+//!    so the methods *build transportable proof objects*. The bridge to
+//!    the shallow model is the soundness map "every point-free derivation
+//!    denotes a valid HOL theorem".
+//!
+//! [`Type`]: covalence_core::Type
+//! [`Term`]: covalence_core::Term
+
+pub mod derived;
+pub mod shallow;
+
+pub use shallow::Hol;
+
+/// Point-free reasoning over the coproduct's symmetric-monoidal
+/// structure, generic over the proof representation. See the
+/// [module docs](self).
+pub trait Monoidal {
+    /// Objects — the "types".
+    type Obj: Clone;
+    /// Morphisms — the "programs" `a → b`.
+    type Hom: Clone;
+    /// An equational proof between two morphisms.
+    type Proof: Clone;
+    /// Failure type for the (partial) constructors and rules.
+    type Error;
+
+    // ---- objects ----
+
+    /// The monoidal product `a ⊕ b` (the coproduct).
+    fn oplus(&self, a: Self::Obj, b: Self::Obj) -> Self::Obj;
+
+    // ---- morphisms: the category vocabulary ----
+
+    /// The identity `id_a : a → a`.
+    fn id(&self, a: Self::Obj) -> Self::Hom;
+    /// Composition `g ∘ f` (apply `f` then `g`).
+    fn comp(&self, g: Self::Hom, f: Self::Hom) -> Result<Self::Hom, Self::Error>;
+
+    // ---- morphisms: the coproduct's join morphisms ----
+
+    /// Left coprojection `inl : a → a ⊕ b`.
+    fn inl(&self, a: Self::Obj, b: Self::Obj) -> Self::Hom;
+    /// Right coprojection `inr : b → a ⊕ b`.
+    fn inr(&self, a: Self::Obj, b: Self::Obj) -> Self::Hom;
+    /// The copairing / **join** `[f, g] : a ⊕ b → c`, given `f : a → c`
+    /// and `g : b → c`.
+    fn copair(&self, f: Self::Hom, g: Self::Hom) -> Result<Self::Hom, Self::Error>;
+    /// The bifunctor action `f ⊕ g : a ⊕ b → a' ⊕ b'`, given `f : a → a'`
+    /// and `g : b → b'`.
+    fn bimap(&self, f: Self::Hom, g: Self::Hom) -> Result<Self::Hom, Self::Error>;
+    /// The symmetry `σ : a ⊕ b → b ⊕ a`.
+    fn swap(&self, a: Self::Obj, b: Self::Obj) -> Result<Self::Hom, Self::Error>;
+    /// The codiagonal / fold `∇ = [id, id] : a ⊕ a → a`.
+    fn codiag(&self, a: Self::Obj) -> Result<Self::Hom, Self::Error>;
+
+    /// The two sides `(lhs, rhs)` of the equation a proof establishes.
+    fn concl(&self, proof: &Self::Proof) -> (Self::Hom, Self::Hom);
+
+    // ---- axioms (as proofs): the category laws ----
+
+    /// `⊢ id ∘ f = f`.
+    fn id_left(&self, f: Self::Hom) -> Result<Self::Proof, Self::Error>;
+    /// `⊢ f ∘ id = f`.
+    fn id_right(&self, f: Self::Hom) -> Result<Self::Proof, Self::Error>;
+    /// `⊢ (h ∘ g) ∘ f = h ∘ (g ∘ f)`.
+    fn assoc(
+        &self,
+        h: Self::Hom,
+        g: Self::Hom,
+        f: Self::Hom,
+    ) -> Result<Self::Proof, Self::Error>;
+
+    // ---- axioms (as proofs): the coproduct universal property ----
+
+    /// **β-left.** `⊢ [f, g] ∘ inl = f`.
+    fn copair_inl(&self, f: Self::Hom, g: Self::Hom) -> Result<Self::Proof, Self::Error>;
+    /// **β-right.** `⊢ [f, g] ∘ inr = g`.
+    fn copair_inr(&self, f: Self::Hom, g: Self::Hom) -> Result<Self::Proof, Self::Error>;
+    /// **η / fusion (uniqueness).** `⊢ m = [m ∘ inl, m ∘ inr]` for any
+    /// `m : a ⊕ b → c`. The principle that a map out of a coproduct is
+    /// determined by its two restrictions — the workhorse for *proving*
+    /// point-free equations.
+    fn fusion(&self, m: Self::Hom) -> Result<Self::Proof, Self::Error>;
+
+    // ---- inference rules: equational logic + congruence ----
+
+    /// `⊢ f = f`.
+    fn refl(&self, f: Self::Hom) -> Result<Self::Proof, Self::Error>;
+    /// From `⊢ f = g` conclude `⊢ g = f`.
+    fn sym(&self, p: Self::Proof) -> Result<Self::Proof, Self::Error>;
+    /// From `⊢ f = g` and `⊢ g = h` conclude `⊢ f = h`.
+    fn trans(&self, p: Self::Proof, q: Self::Proof) -> Result<Self::Proof, Self::Error>;
+    /// From `⊢ g = g'` and `⊢ f = f'` conclude `⊢ g ∘ f = g' ∘ f'`.
+    fn comp_cong(
+        &self,
+        g_eq: Self::Proof,
+        f_eq: Self::Proof,
+    ) -> Result<Self::Proof, Self::Error>;
+    /// From `⊢ f = f'` and `⊢ g = g'` conclude `⊢ [f, g] = [f', g']`.
+    fn copair_cong(
+        &self,
+        f_eq: Self::Proof,
+        g_eq: Self::Proof,
+    ) -> Result<Self::Proof, Self::Error>;
+}

--- a/crates/covalence-hol/src/monoidal/shallow.rs
+++ b/crates/covalence-hol/src/monoidal/shallow.rs
@@ -11,8 +11,10 @@
 //! shallow point-free proof is an outright HOL theorem — nothing is
 //! postulated.
 
+use covalence_core::defs::coprod_spec;
 use covalence_core::{Error, Result, Term, Thm, Type, TypeKind};
 
+use crate::init::ext::TermExt;
 use crate::init::{cat, coprod};
 use crate::monoidal::Monoidal;
 
@@ -32,7 +34,7 @@ impl Hol {
 fn fun_parts(ty: &Type) -> Result<(Type, Type)> {
     match ty.kind() {
         TypeKind::Fun(dom, cod) => Ok((dom.clone(), cod.clone())),
-        _ => Err(Error::NotBool(ty.clone())),
+        _ => Err(Error::NotFunction(ty.clone())),
     }
 }
 
@@ -42,18 +44,8 @@ impl Hol {
         let (a, c) = fun_parts(&f.type_of()?)?;
         let (b, _c) = fun_parts(&g.type_of()?)?;
         coprod::coprod_case(a, b, c)
-            .apply2(f.clone(), g.clone())
-    }
-}
-
-/// Tiny `.apply`-twice helper, kept local to avoid leaking it.
-trait Apply2 {
-    fn apply2(self, x: Term, y: Term) -> Result<Term>;
-}
-impl Apply2 for Term {
-    fn apply2(self, x: Term, y: Term) -> Result<Term> {
-        use crate::init::ext::TermExt;
-        self.apply(x)?.apply(y)
+            .apply(f.clone())?
+            .apply(g.clone())
     }
 }
 
@@ -197,11 +189,17 @@ impl Monoidal for Hol {
     }
 }
 
-/// Split a `coprod a b` type into `(a, b)`.
+/// Split a `coprod a b` type into `(a, b)` (the domain of a map out of a
+/// coproduct). Errors unless `ty` really is a `coprod` instance.
 fn coprod_parts(ty: &Type) -> Result<(Type, Type)> {
     match ty.kind() {
-        TypeKind::Spec(_spec, args) if args.len() == 2 => Ok((args[0].clone(), args[1].clone())),
-        _ => Err(Error::NotBool(ty.clone())),
+        TypeKind::Spec(spec, args) if spec.ptr_eq(&coprod_spec()) && args.len() == 2 => {
+            Ok((args[0].clone(), args[1].clone()))
+        }
+        _ => Err(Error::TypeMismatch {
+            expected: coprod::coprod(Type::tfree("a"), Type::tfree("b")),
+            got: ty.clone(),
+        }),
     }
 }
 

--- a/crates/covalence-hol/src/monoidal/shallow.rs
+++ b/crates/covalence-hol/src/monoidal/shallow.rs
@@ -1,0 +1,291 @@
+//! The **shallow** embedding of point-free reasoning into HOL: an object
+//! is a HOL [`Type`], a morphism is a HOL `α → β` [`Term`], and a proof
+//! is a HOL [`Thm`] equating two morphisms.
+//!
+//! [`Hol`] is the trivial implementation of [`Monoidal`] — "trivial"
+//! because point-free reasoning is *just* HOL reasoning about functions
+//! and the `coprod` type. Every axiom forwards to a genuine,
+//! hypothesis-free theorem: the category laws to
+//! [`init::cat`](crate::init::cat) and the coproduct universal property
+//! (β-laws + η/fusion) to [`init::coprod`](crate::init::coprod). So a
+//! shallow point-free proof is an outright HOL theorem — nothing is
+//! postulated.
+
+use covalence_core::{Error, Result, Term, Thm, Type, TypeKind};
+
+use crate::init::{cat, coprod};
+use crate::monoidal::Monoidal;
+
+/// Shallow point-free-in-HOL: `Obj = Type`, `Hom = Term`, `Proof = Thm`.
+/// Zero-sized.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Hol;
+
+impl Hol {
+    /// Construct a handle. Free; no allocation.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Split `α → β` into `(α, β)`.
+fn fun_parts(ty: &Type) -> Result<(Type, Type)> {
+    match ty.kind() {
+        TypeKind::Fun(dom, cod) => Ok((dom.clone(), cod.clone())),
+        _ => Err(Error::NotBool(ty.clone())),
+    }
+}
+
+impl Hol {
+    /// `[f, g] : a ⊕ b → c` as a raw term (`f : a → c`, `g : b → c`).
+    fn copair_term(&self, f: &Term, g: &Term) -> Result<Term> {
+        let (a, c) = fun_parts(&f.type_of()?)?;
+        let (b, _c) = fun_parts(&g.type_of()?)?;
+        coprod::coprod_case(a, b, c)
+            .apply2(f.clone(), g.clone())
+    }
+}
+
+/// Tiny `.apply`-twice helper, kept local to avoid leaking it.
+trait Apply2 {
+    fn apply2(self, x: Term, y: Term) -> Result<Term>;
+}
+impl Apply2 for Term {
+    fn apply2(self, x: Term, y: Term) -> Result<Term> {
+        use crate::init::ext::TermExt;
+        self.apply(x)?.apply(y)
+    }
+}
+
+impl Monoidal for Hol {
+    type Obj = Type;
+    type Hom = Term;
+    type Proof = Thm;
+    type Error = Error;
+
+    // ---- objects ----
+
+    fn oplus(&self, a: Type, b: Type) -> Type {
+        coprod::coprod(a, b)
+    }
+
+    // ---- morphisms: category ----
+
+    fn id(&self, a: Type) -> Term {
+        cat::id(a)
+    }
+
+    fn comp(&self, g: Term, f: Term) -> Result<Term> {
+        cat::comp(&g, &f)
+    }
+
+    // ---- morphisms: coproduct join morphisms ----
+
+    fn inl(&self, a: Type, b: Type) -> Term {
+        coprod::inl(a, b)
+    }
+
+    fn inr(&self, a: Type, b: Type) -> Term {
+        coprod::inr(a, b)
+    }
+
+    fn copair(&self, f: Term, g: Term) -> Result<Term> {
+        self.copair_term(&f, &g)
+    }
+
+    fn bimap(&self, f: Term, g: Term) -> Result<Term> {
+        // f : a → a', g : b → b'  ⟹  f ⊕ g = [inl' ∘ f, inr' ∘ g].
+        let (_a, a2) = fun_parts(&f.type_of()?)?;
+        let (_b, b2) = fun_parts(&g.type_of()?)?;
+        let inl2 = self.inl(a2.clone(), b2.clone());
+        let inr2 = self.inr(a2, b2);
+        let left = cat::comp(&inl2, &f)?;
+        let right = cat::comp(&inr2, &g)?;
+        self.copair_term(&left, &right)
+    }
+
+    fn swap(&self, a: Type, b: Type) -> Result<Term> {
+        // σ : a ⊕ b → b ⊕ a = [inr_{b,a}, inl_{b,a}].
+        let left = self.inr(b.clone(), a.clone()); // a → b ⊕ a
+        let right = self.inl(b, a); // b → b ⊕ a
+        self.copair_term(&left, &right)
+    }
+
+    fn codiag(&self, a: Type) -> Result<Term> {
+        let id = self.id(a);
+        self.copair_term(&id, &id)
+    }
+
+    fn concl(&self, proof: &Thm) -> (Term, Term) {
+        let (l, r) = proof.concl().as_eq().expect("a monoidal proof is an equation");
+        (l.clone(), r.clone())
+    }
+
+    // ---- axioms: category laws ----
+
+    fn id_left(&self, f: Term) -> Result<Thm> {
+        cat::id_left(&f)
+    }
+
+    fn id_right(&self, f: Term) -> Result<Thm> {
+        cat::id_right(&f)
+    }
+
+    fn assoc(&self, h: Term, g: Term, f: Term) -> Result<Thm> {
+        cat::comp_assoc(&h, &g, &f)
+    }
+
+    // ---- axioms: coproduct universal property ----
+
+    fn copair_inl(&self, f: Term, g: Term) -> Result<Thm> {
+        // ⊢ [f, g] ∘ inl = f, via the pointwise β-law + extensionality.
+        let (a, c) = fun_parts(&f.type_of()?)?;
+        let (b, _c) = fun_parts(&g.type_of()?)?;
+        let cp = self.copair_term(&f, &g)?;
+        let lhs = cat::comp(&cp, &self.inl(a.clone(), b.clone()))?;
+        let x = Term::free("__cpx", a.clone());
+        let app_eq = cat::comp_beta(&lhs, &x)? // ⊢ ([f,g]∘inl) x = [f,g](inl x)
+            .trans(coprod::case_inl(&a, &b, &c, &f, &g, &x)?)?; // ⊢ … = f x
+        cat::fun_ext(app_eq, "__cpx", &a)
+    }
+
+    fn copair_inr(&self, f: Term, g: Term) -> Result<Thm> {
+        let (a, c) = fun_parts(&f.type_of()?)?;
+        let (b, _c) = fun_parts(&g.type_of()?)?;
+        let cp = self.copair_term(&f, &g)?;
+        let lhs = cat::comp(&cp, &self.inr(a.clone(), b.clone()))?;
+        let y = Term::free("__cpy", b.clone());
+        let app_eq = cat::comp_beta(&lhs, &y)?
+            .trans(coprod::case_inr(&a, &b, &c, &f, &g, &y)?)?;
+        cat::fun_ext(app_eq, "__cpy", &b)
+    }
+
+    fn fusion(&self, m: Term) -> Result<Thm> {
+        // m : a ⊕ b → c.
+        let (dom, c) = fun_parts(&m.type_of()?)?;
+        let (a, b) = coprod_parts(&dom)?;
+        coprod::case_eta(&a, &b, &c, &m)
+    }
+
+    // ---- inference rules ----
+
+    fn refl(&self, f: Term) -> Result<Thm> {
+        Thm::refl(f)
+    }
+
+    fn sym(&self, p: Thm) -> Result<Thm> {
+        p.sym()
+    }
+
+    fn trans(&self, p: Thm, q: Thm) -> Result<Thm> {
+        p.trans(q)
+    }
+
+    fn comp_cong(&self, g_eq: Thm, f_eq: Thm) -> Result<Thm> {
+        cat::comp_cong(&g_eq, &f_eq)
+    }
+
+    fn copair_cong(&self, f_eq: Thm, g_eq: Thm) -> Result<Thm> {
+        // ⊢ [f, g] = [f', g'] by congruence on `coprod_case`.
+        let (f, _f2) = f_eq.concl().as_eq().ok_or(Error::NotAnEquation)?;
+        let (g, _g2) = g_eq.concl().as_eq().ok_or(Error::NotAnEquation)?;
+        let (a, c) = fun_parts(&f.type_of()?)?;
+        let (b, _c) = fun_parts(&g.type_of()?)?;
+        Thm::refl(coprod::coprod_case(a, b, c))?
+            .cong_app(f_eq)?
+            .cong_app(g_eq)
+    }
+}
+
+/// Split a `coprod a b` type into `(a, b)`.
+fn coprod_parts(ty: &Type) -> Result<(Type, Type)> {
+    match ty.kind() {
+        TypeKind::Spec(_spec, args) if args.len() == 2 => Ok((args[0].clone(), args[1].clone())),
+        _ => Err(Error::NotBool(ty.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(n: &str) -> Type {
+        Type::tfree(n)
+    }
+
+    fn hol() -> Hol {
+        Hol::new()
+    }
+
+    #[test]
+    fn copair_beta_laws_are_genuine() {
+        let h = hol();
+        let (a, b, c) = (obj("a"), obj("b"), obj("c"));
+        let f = Term::free("f", Type::fun(a.clone(), c.clone()));
+        let g = Term::free("g", Type::fun(b.clone(), c.clone()));
+        let l = h.copair_inl(f.clone(), g.clone()).unwrap();
+        let r = h.copair_inr(f.clone(), g.clone()).unwrap();
+        assert!(l.hyps().is_empty() && l.has_no_obs());
+        assert!(r.hyps().is_empty() && r.has_no_obs());
+        // [f,g] ∘ inl = f  and  [f,g] ∘ inr = g.
+        assert_eq!(h.concl(&l).1, f);
+        assert_eq!(h.concl(&r).1, g);
+    }
+
+    #[test]
+    fn fusion_is_genuine() {
+        let h = hol();
+        let (a, b, c) = (obj("a"), obj("b"), obj("c"));
+        let m = Term::free("m", Type::fun(h.oplus(a, b), c));
+        let p = h.fusion(m.clone()).unwrap();
+        assert!(p.hyps().is_empty() && p.has_no_obs());
+        assert_eq!(h.concl(&p).0, m);
+    }
+
+    #[test]
+    fn derived_swap_involution_is_genuine() {
+        // ⊢ σ_{b,a} ∘ σ_{a,b} = id, proved through the trait API only.
+        use crate::monoidal::derived::swap_involution;
+        let h = hol();
+        let (a, b) = (obj("a"), obj("b"));
+        let p = swap_involution(&h, a.clone(), b.clone()).unwrap();
+        assert!(p.hyps().is_empty(), "derived from proved axioms only");
+        assert!(p.has_no_obs());
+        // RHS is the identity on a ⊕ b.
+        let (_lhs, rhs) = h.concl(&p);
+        assert_eq!(rhs, h.id(h.oplus(a, b)));
+    }
+
+    #[test]
+    fn derived_swap_injection_laws() {
+        use crate::monoidal::derived::{swap_inl, swap_inr};
+        let h = hol();
+        let (a, b) = (obj("a"), obj("b"));
+        // σ∘inl = inr, σ∘inr = inl.
+        let l = swap_inl(&h, a.clone(), b.clone()).unwrap();
+        let r = swap_inr(&h, a.clone(), b.clone()).unwrap();
+        assert_eq!(h.concl(&l).1, h.inr(b.clone(), a.clone()));
+        assert_eq!(h.concl(&r).1, h.inl(b, a));
+    }
+
+    #[test]
+    fn structural_morphisms_typecheck() {
+        let h = hol();
+        let (a, b) = (obj("a"), obj("b"));
+        // swap : a⊕b → b⊕a, codiag : a⊕a → a, bimap of ids.
+        let sw = h.swap(a.clone(), b.clone()).unwrap();
+        assert_eq!(
+            sw.type_of().unwrap(),
+            Type::fun(h.oplus(a.clone(), b.clone()), h.oplus(b.clone(), a.clone()))
+        );
+        let nabla = h.codiag(a.clone()).unwrap();
+        assert_eq!(nabla.type_of().unwrap(), Type::fun(h.oplus(a.clone(), a.clone()), a.clone()));
+        let bi = h
+            .bimap(h.id(a.clone()), h.id(b.clone()))
+            .unwrap();
+        assert_eq!(
+            bi.type_of().unwrap(),
+            Type::fun(h.oplus(a.clone(), b.clone()), h.oplus(a, b))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a high-level, point-free ("pointless") programming API for reasoning about the coproduct's symmetric-monoidal structure, in the style of `covalence-hol/peano`: a `Monoidal` trait (objects / morphisms / equational proofs) with a shallow HOL implementation.

**Everything is genuinely proved — no postulates, no hypotheses, no oracles.** Each axiom in the shallow model forwards to a hypothesis- and obs-free HOL theorem; the derived theorems are real derivations on top.

## What's here

### `init/cat.rs` — the category structure on HOL functions
Composition (`fun.compose`) and identity (`fun.id`) already existed in `defs/`; this proves the laws that make them a category, point-free (δβ-normalise both sides at a fresh point, then re-abstract + η-contract):
- `id_left` (`id ∘ f = f`), `id_right` (`f ∘ id = f`), `comp_assoc` (`(h∘g)∘f = h∘(g∘f)`)
- plus `comp` (typed composition of terms), `comp_cong`, `comp_beta`, and a reusable `fun_ext`.

### `init/coprod.rs` — the coproduct universal property
The module previously had only the round-trips/disjointness, with the `coprod_case` equations marked "still to come". Now proved:
- `case_inl` / `case_inr` — the β-equations (`coprod_case f g (inl a) = f a`), via the Hilbert-ε argument (mirroring `cond.rs`) plus injection-relation injectivity and disjointness;
- `cases` — surjectivity (every value is `inl` or `inr`), via the subtype back-direction;
- `case_eta` — the η/fusion law (`m = [m∘inl, m∘inr]`).

### `monoidal/` — the trait + shallow model + derived proofs
- `Monoidal` trait: objects (`⊕`), morphisms (`id`, `comp`, `inl`/`inr`, `copair` = join `[f,g]`, `bimap` = `f⊕g`, `swap` = σ, `codiag` = ∇), the axioms (category laws + copairing β-laws + fusion) and inference rules (refl/sym/trans + comp/copair congruence).
- `shallow::Hol` forwards each axiom to the `cat`/`coprod` theorems above.
- `derived.rs` proves coherence facts **through the trait API alone**: `copair_unique` (extensionality for maps out of `⊕`) and the flagship `swap_involution` (`σ ∘ σ = id`).

## Scope / notes

- The task asked to "axiomatize"; since the coproduct β/η laws turned out tractable to *prove* from existing kernel machinery, they're proved rather than postulated, keeping the crate's no-postulates invariant. The trait *interface* is still the axiomatization (the way `Peano` is).
- This is a deliberate "start": the symmetry/braiding, codiagonal, and bifunctor are in; the **unit object (initial type) and the unitor/associator coherence morphisms are not yet added** — noted in the module docs as the natural next step, derivable from the same axioms.
- No new `SKELETONS.md` entries (nothing is stubbed).

## Testing

`cargo test -p covalence-hol` — 142 passed, 0 failed; clean `cargo clippy`. New tests cover each genuine theorem (hypothesis-free + obs-free assertions), the structural morphisms' types, and the derived `swap_involution` / swap injection laws driven through the trait.

https://claude.ai/code/session_01S5zed5hheLP2RhYUbHc2cb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5zed5hheLP2RhYUbHc2cb)_