### PR TITLE
docs: spec the cog git store for dogfooding test assets

### DIFF
--- a/crates/covalence-git/Cargo.toml
+++ b/crates/covalence-git/Cargo.toml
@@ -8,6 +8,9 @@ object-store = ["dep:covalence-store", "dep:flate2"]
 odb = ["object-store", "dep:gix-odb", "dep:gix-object"]
 lfs = ["dep:covalence-store"]
 sqlite = ["object-store", "dep:covalence-sqlite"]
+# Per-repo cog store under `.git/cog-<uuid>/`: a SQLite blob store, a
+# BLAKE3 loose-object store for large blobs, and the path/discovery glue.
+cog = ["sqlite", "covalence-store/sqlite"]
 clone = ["sqlite", "odb", "dep:ureq", "dep:covalence-object"]
 # Async wrapper over `clone` that runs the sync clone on tokio's blocking
 # pool, suitable for axum handlers and other tokio contexts.

--- a/crates/covalence-git/src/cog/loose.rs
+++ b/crates/covalence-git/src/cog/loose.rs
@@ -1,0 +1,177 @@
+//! BLAKE3-keyed loose-object store.
+//!
+//! A content-addressed store of raw (uncompressed, unframed) files laid
+//! out in a git-style fan-out directory: `{dir}/{hex[0:2]}/{hex[2:]}`,
+//! keyed by the BLAKE3 hash of the content (`O256::blob`).
+//!
+//! Mirrors [`LfsStore`](crate::lfs::LfsStore) but keyed by BLAKE3 rather
+//! than SHA-256, so a file's loose-store key equals its `O256` content
+//! id everywhere else in covalence. Intended for *large* blobs that
+//! would bloat the SQLite store; small blobs stay in SQLite (see
+//! [`SizeRouter`](covalence_store::SizeRouter)).
+
+use std::fs::{self, File};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use covalence_hash::O256;
+use covalence_store::{BlobInfo, ContentStore, StoreError, clip_slice};
+
+/// A BLAKE3-keyed loose-object store rooted at a directory.
+#[derive(Debug, Clone)]
+pub struct Blake3LooseStore {
+    dir: PathBuf,
+}
+
+impl Blake3LooseStore {
+    /// Create a store rooted at `dir` (typically `.git/cog-<uuid>/objects`).
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// The git-style fan-out path for `key`: `{dir}/{hex[0:2]}/{hex[2:]}`.
+    fn object_path(&self, key: &O256) -> PathBuf {
+        let hex = key.to_string();
+        self.dir.join(&hex[..2]).join(&hex[2..])
+    }
+
+    /// Write raw `data` to `key`'s path atomically (temp file + rename).
+    /// Idempotent: an existing object is left untouched.
+    fn write_raw(&self, key: &O256, data: &[u8]) -> Result<(), StoreError> {
+        let path = self.object_path(key);
+        if path.exists() {
+            return Ok(());
+        }
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| StoreError::Io(format!("mkdir {}: {e}", parent.display())))?;
+        }
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = self.dir.join(format!("tmp_{}_{n}", std::process::id()));
+        fs::write(&tmp, data).map_err(|e| StoreError::Io(format!("write {}: {e}", tmp.display())))?;
+        fs::rename(&tmp, &path)
+            .map_err(|e| StoreError::Io(format!("rename → {}: {e}", path.display())))?;
+        Ok(())
+    }
+}
+
+impl ContentStore<O256> for Blake3LooseStore {
+    fn put(&self, key: O256, data: &[u8]) -> Result<(), StoreError> {
+        let computed = O256::blob(data);
+        if computed != key {
+            return Err(StoreError::Io(format!(
+                "loose-store hash mismatch: expected {key}, computed {computed}",
+            )));
+        }
+        self.write_raw(&key, data)
+    }
+
+    fn insert(&self, data: &[u8]) -> Result<O256, StoreError> {
+        let key = O256::blob(data);
+        self.write_raw(&key, data)?;
+        Ok(key)
+    }
+
+    fn get(&self, key: &O256) -> Option<Vec<u8>> {
+        fs::read(self.object_path(key)).ok()
+    }
+
+    fn head(&self, key: &O256) -> Option<BlobInfo> {
+        fs::metadata(self.object_path(key))
+            .ok()
+            .map(|m| BlobInfo { size: m.len() })
+    }
+
+    fn contains(&self, key: &O256) -> bool {
+        self.object_path(key).exists()
+    }
+
+    /// Native partial read: stat for length, then seek + read the clipped
+    /// range without pulling the whole blob into memory.
+    fn get_slice(&self, key: &O256, range: std::ops::Range<u64>) -> Result<Vec<u8>, StoreError> {
+        let path = self.object_path(key);
+        let mut file = match File::open(&path) {
+            Ok(f) => f,
+            Err(_) => return Err(StoreError::NotFound),
+        };
+        let total = file
+            .metadata()
+            .map_err(|e| StoreError::Io(format!("stat {}: {e}", path.display())))?
+            .len();
+        let Some(clipped) = clip_slice(total, range)? else {
+            return Ok(Vec::new());
+        };
+        file.seek(SeekFrom::Start(clipped.start as u64))
+            .map_err(|e| StoreError::Io(format!("seek {}: {e}", path.display())))?;
+        let mut buf = vec![0u8; clipped.end - clipped.start];
+        file.read_exact(&mut buf)
+            .map_err(|e| StoreError::Io(format!("read {}: {e}", path.display())))?;
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("cov_cog_loose_{name}_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn round_trip_and_fanout() {
+        let dir = test_dir("rt");
+        let store = Blake3LooseStore::new(&dir);
+        let data = b"loose blob content";
+        let key = store.insert(data).unwrap();
+        assert_eq!(key, O256::blob(data));
+        assert!(store.contains(&key));
+        assert_eq!(store.get(&key).unwrap(), data);
+
+        let hex = key.to_string();
+        assert!(dir.join(&hex[..2]).join(&hex[2..]).exists());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn native_range_read() {
+        let dir = test_dir("range");
+        let store = Blake3LooseStore::new(&dir);
+        let key = store.insert(b"0123456789").unwrap();
+        assert_eq!(store.head(&key).unwrap().size, 10);
+        assert_eq!(store.get_slice(&key, 2..5).unwrap(), b"234");
+        // end past total clamps (POSIX read semantics).
+        assert_eq!(store.get_slice(&key, 8..100).unwrap(), b"89");
+        // start >= end is empty.
+        assert_eq!(store.get_slice(&key, 5..5).unwrap(), b"");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_is_not_found() {
+        let dir = test_dir("missing");
+        let store = Blake3LooseStore::new(&dir);
+        let absent = O256::blob(b"absent");
+        assert!(store.get(&absent).is_none());
+        assert!(!store.contains(&absent));
+        assert!(matches!(
+            store.get_slice(&absent, 0..1),
+            Err(StoreError::NotFound)
+        ));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn put_rejects_mismatched_key() {
+        let dir = test_dir("mismatch");
+        let store = Blake3LooseStore::new(&dir);
+        let wrong = O256::blob(b"wrong");
+        assert!(store.put(wrong, b"right").is_err());
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/covalence-git/src/cog/mod.rs
+++ b/crates/covalence-git/src/cog/mod.rs
@@ -1,0 +1,266 @@
+//! Per-repo cog store living inside an existing `.git` directory.
+//!
+//! A repository already carries a content-addressed object database under
+//! `.git`. The cog store is a sibling database next to it — keyed by
+//! BLAKE3 (`O256`) instead of git's SHA — anchored at the git
+//! **commondir** so all linked worktrees share one cache. It is
+//! auto-ignored (nothing under `.git` is tracked), travels with the
+//! gitdir, and needs no global install.
+//!
+//! The directory is `.git/cog-<COG_STORE_UUID>/`; the trailing UUID is a
+//! fixed, well-known marker that makes the directory unmistakable and
+//! collision-proof against any future git feature or other tool named
+//! "cog".
+//!
+//! Layout:
+//! ```text
+//! .git/cog-<uuid>/
+//!   store.db    SQLite ContentStore<O256>  (small blobs)
+//!   objects/    BLAKE3 loose store         (large blobs)
+//!   sources.json  remote upstreams + url->hash cache   (later)
+//! ```
+
+mod loose;
+pub use loose::Blake3LooseStore;
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use covalence_hash::O256;
+use covalence_store::{BlobStore, SizeRouter, SqliteStore, StoreError};
+
+/// The one well-known cog-store directory UUID. Never changes.
+pub const COG_STORE_UUID: &str = "14169d9d-e25f-46dd-abc7-dd53b495cd06";
+
+/// The cog-store directory name: `cog-<COG_STORE_UUID>`.
+pub const COG_STORE_DIRNAME: &str = "cog-14169d9d-e25f-46dd-abc7-dd53b495cd06";
+
+/// Handle to a cog-store directory inside a git repository.
+///
+/// Pure path logic plus thin opener helpers; constructing the handle
+/// neither touches the filesystem nor creates anything until you call
+/// [`create`](Self::create) or one of the `open_*` methods.
+#[derive(Debug, Clone)]
+pub struct CogStoreDir {
+    dir: PathBuf,
+}
+
+impl CogStoreDir {
+    /// Anchor the store at an already-resolved git common directory: the
+    /// store lives at `<commondir>/cog-<uuid>/`.
+    pub fn at_commondir(commondir: &Path) -> Self {
+        Self {
+            dir: commondir.join(COG_STORE_DIRNAME),
+        }
+    }
+
+    /// Resolve the commondir for a repository root (a worktree root, a
+    /// `.git` directory, or a bare gitdir) and anchor the store there.
+    pub fn from_repo_root(repo_root: &Path) -> io::Result<Self> {
+        Ok(Self::at_commondir(&resolve_commondir(repo_root)?))
+    }
+
+    /// Walk up from the current working directory to the enclosing
+    /// repository and anchor the store at its commondir. Returns `None`
+    /// if no git repository encloses the cwd.
+    pub fn discover() -> io::Result<Option<Self>> {
+        let cwd = std::env::current_dir()?;
+        let start = fs::canonicalize(&cwd).unwrap_or(cwd);
+        for dir in start.ancestors() {
+            if is_repo_root(dir) {
+                return Ok(Some(Self::from_repo_root(dir)?));
+            }
+        }
+        Ok(None)
+    }
+
+    /// The store directory (`.git/cog-<uuid>/`).
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Path to the default SQLite blob store (`store.db`).
+    pub fn db_path(&self) -> PathBuf {
+        self.dir.join("store.db")
+    }
+
+    /// Path to the BLAKE3 loose-object directory (`objects/`).
+    pub fn objects_dir(&self) -> PathBuf {
+        self.dir.join("objects")
+    }
+
+    /// Path to the remote-source descriptor (`sources.json`).
+    pub fn sources_path(&self) -> PathBuf {
+        self.dir.join("sources.json")
+    }
+
+    /// Create the store directory (`mkdir -p`).
+    pub fn create(&self) -> io::Result<()> {
+        fs::create_dir_all(&self.dir)
+    }
+
+    /// Open (creating if absent) the SQLite blob store at `store.db`.
+    pub fn open_sqlite(&self) -> Result<SqliteStore, StoreError> {
+        self.create().map_err(|e| StoreError::Io(e.to_string()))?;
+        SqliteStore::open(self.db_path()).map_err(|e| StoreError::Io(e.to_string()))
+    }
+
+    /// A BLAKE3 loose-object store over `objects/` (the directory is
+    /// created lazily on first write).
+    pub fn loose(&self) -> Blake3LooseStore {
+        Blake3LooseStore::new(self.objects_dir())
+    }
+
+    /// The opinionated default store: a single SQLite `ContentStore<O256>`.
+    pub fn open_default(&self) -> Result<BlobStore<O256>, StoreError> {
+        Ok(BlobStore::new(self.open_sqlite()?))
+    }
+
+    /// A size-routed store: small blobs to SQLite, large blobs (`>=
+    /// threshold` bytes) to the BLAKE3 loose store; reads consult both.
+    pub fn open_routed(&self, threshold: u64) -> Result<BlobStore<O256>, StoreError> {
+        let small = BlobStore::new(self.open_sqlite()?);
+        let large = BlobStore::new(self.loose());
+        Ok(BlobStore::new(SizeRouter::new(small, large, threshold)))
+    }
+}
+
+/// True if `dir` looks like a repository root: it contains `.git`
+/// (worktree, file or directory) or is itself a bare gitdir.
+fn is_repo_root(dir: &Path) -> bool {
+    if fs::symlink_metadata(dir.join(".git")).is_ok() {
+        return true;
+    }
+    dir.join("objects").is_dir() && dir.join("HEAD").is_file()
+}
+
+/// Resolve the shared common directory for a repository root.
+///
+/// Handles worktree roots (`<root>/.git` directory), linked-worktree
+/// gitlinks (`<root>/.git` is a `gitdir: <path>` file), and bare
+/// repositories (the input is itself the gitdir). The commondir is the
+/// gitdir unless a `commondir` pointer file redirects it (linked
+/// worktrees), so every worktree shares one store.
+fn resolve_commondir(repo_root: &Path) -> io::Result<PathBuf> {
+    let gitdir = resolve_gitdir(repo_root)?;
+    let commondir = match fs::read_to_string(gitdir.join("commondir")) {
+        Ok(s) => {
+            let joined = gitdir.join(s.trim());
+            fs::canonicalize(&joined).unwrap_or(joined)
+        }
+        Err(_) => gitdir.clone(),
+    };
+    Ok(commondir)
+}
+
+/// Resolve a repository root to its (per-worktree) gitdir.
+fn resolve_gitdir(repo_root: &Path) -> io::Result<PathBuf> {
+    let dot_git = repo_root.join(".git");
+    match fs::symlink_metadata(&dot_git) {
+        Ok(m) if m.is_file() => {
+            // Linked-worktree gitlink: `gitdir: <path>`.
+            let content = fs::read_to_string(&dot_git)?;
+            let rest = content
+                .lines()
+                .find_map(|l| l.strip_prefix("gitdir:"))
+                .map(str::trim)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("{}: malformed gitlink", dot_git.display()),
+                    )
+                })?;
+            let p = PathBuf::from(rest);
+            let abs = if p.is_absolute() { p } else { repo_root.join(p) };
+            Ok(fs::canonicalize(&abs).unwrap_or(abs))
+        }
+        Ok(_) => Ok(dot_git), // `.git` directory: ordinary worktree.
+        Err(_) => {
+            // Bare repository: the root is itself the gitdir.
+            if repo_root.join("objects").is_dir() && repo_root.join("HEAD").is_file() {
+                Ok(repo_root.to_path_buf())
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("not a git repository: {}", repo_root.display()),
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use covalence_store::ContentStore;
+
+    fn fresh(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("cov_cog_dir_{name}_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn dirname_matches_uuid() {
+        assert_eq!(COG_STORE_DIRNAME, format!("cog-{COG_STORE_UUID}"));
+    }
+
+    #[test]
+    fn worktree_commondir_is_dot_git() {
+        let root = fresh("worktree");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        let cog = CogStoreDir::from_repo_root(&root).unwrap();
+        assert_eq!(cog.dir(), root.join(".git").join(COG_STORE_DIRNAME));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn linked_worktree_follows_gitlink() {
+        let root = fresh("linked");
+        let common = root.join("main/.git");
+        let wt_gitdir = common.join("worktrees/wt");
+        fs::create_dir_all(&wt_gitdir).unwrap();
+        fs::create_dir_all(common.join("objects")).unwrap();
+        // The linked worktree's gitdir points back at the common dir.
+        fs::write(wt_gitdir.join("commondir"), "../..\n").unwrap();
+        let wt = root.join("wt");
+        fs::create_dir_all(&wt).unwrap();
+        fs::write(wt.join(".git"), format!("gitdir: {}\n", wt_gitdir.display())).unwrap();
+
+        let cog = CogStoreDir::from_repo_root(&wt).unwrap();
+        assert_eq!(cog.dir(), common.join(COG_STORE_DIRNAME));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn open_default_round_trips() {
+        let root = fresh("default");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        let cog = CogStoreDir::from_repo_root(&root).unwrap();
+        let store = cog.open_default().unwrap();
+        let key = store.insert(b"hello cog").unwrap();
+        assert_eq!(store.get(&key).unwrap(), b"hello cog");
+        assert!(cog.db_path().exists());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn open_routed_splits_by_size() {
+        let root = fresh("routed");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        let cog = CogStoreDir::from_repo_root(&root).unwrap();
+        let store = cog.open_routed(8).unwrap();
+
+        let small = store.insert(b"tiny").unwrap();
+        let large = store.insert(b"a clearly larger blob").unwrap();
+        assert_eq!(store.get(&small).unwrap(), b"tiny");
+        assert_eq!(store.get(&large).unwrap(), b"a clearly larger blob");
+
+        // The large blob landed in the loose store, the small one did not.
+        assert!(cog.loose().contains(&large));
+        assert!(!cog.loose().contains(&small));
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/crates/covalence-git/src/lib.rs
+++ b/crates/covalence-git/src/lib.rs
@@ -21,6 +21,9 @@ pub mod lfs;
 #[cfg(feature = "clone")]
 pub mod clone;
 
+#[cfg(feature = "cog")]
+pub mod cog;
+
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Hash algorithm for `hash_blob`.

--- a/crates/covalence-store/src/lib.rs
+++ b/crates/covalence-store/src/lib.rs
@@ -10,6 +10,9 @@ pub use object::{
 mod range;
 pub use range::{BlobInfo, ByteRange, ResolvedRange, clip_slice, slice_range};
 
+mod overlay;
+pub use overlay::{DEFAULT_SIZE_THRESHOLD, OverlayStore, SizeRouter};
+
 // ---------------------------------------------------------------------------
 // TreeStore — POSIX-style virtual filesystem trait
 // ---------------------------------------------------------------------------

--- a/crates/covalence-store/src/overlay.rs
+++ b/crates/covalence-store/src/overlay.rs
@@ -1,0 +1,243 @@
+//! Store combinators: read-fallback overlay and size-based write routing.
+//!
+//! Neither type is content-aware — they compose any
+//! [`ContentStore<K>`](crate::ContentStore) layers behind the same
+//! [`BlobStore<K>`](crate::BlobStore) facade. They are the native,
+//! hand-wired analogue of a [`StoreManifest`](crate::metadata)
+//! `depends_on` graph.
+//!
+//! - [`OverlayStore`] — reads try each layer in order, first hit wins;
+//!   writes go to a single writable primary.
+//! - [`SizeRouter`] — writes route by blob size (small vs. large);
+//!   reads consult both layers.
+
+use crate::{BlobInfo, BlobStore, ByteRange, ContentStore, ResolvedRange, StoreError};
+
+/// Read-fallback / write-routing overlay over a stack of stores.
+///
+/// Reads consult `primary` first, then each store in `fallbacks` in
+/// order, and the first hit wins. Writes (`put`/`insert`) always go to
+/// `primary` — the single writable layer. Fallbacks are read-only as far
+/// as this store is concerned.
+///
+/// Mirrors [`StoreManifest`](crate::metadata) `depends_on`: a missing or
+/// empty fallback is survivable, not a correctness bug.
+pub struct OverlayStore<K> {
+    primary: BlobStore<K>,
+    fallbacks: Vec<BlobStore<K>>,
+}
+
+impl<K: Send + Sync> OverlayStore<K> {
+    /// Build an overlay with a writable `primary` and ordered read-only
+    /// `fallbacks`.
+    pub fn new(primary: BlobStore<K>, fallbacks: Vec<BlobStore<K>>) -> Self {
+        Self { primary, fallbacks }
+    }
+
+    /// Add another read-only fallback at the end of the chain.
+    pub fn push_fallback(&mut self, store: BlobStore<K>) {
+        self.fallbacks.push(store);
+    }
+
+    /// Iterate every layer in read order: primary, then fallbacks.
+    fn layers(&self) -> impl Iterator<Item = &BlobStore<K>> {
+        std::iter::once(&self.primary).chain(self.fallbacks.iter())
+    }
+}
+
+impl<K: Send + Sync> ContentStore<K> for OverlayStore<K> {
+    fn put(&self, key: K, data: &[u8]) -> Result<(), StoreError> {
+        self.primary.put(key, data)
+    }
+
+    fn insert(&self, data: &[u8]) -> Result<K, StoreError> {
+        self.primary.insert(data)
+    }
+
+    fn get(&self, key: &K) -> Option<Vec<u8>> {
+        self.layers().find_map(|s| s.get(key))
+    }
+
+    fn get_slice(&self, key: &K, range: std::ops::Range<u64>) -> Result<Vec<u8>, StoreError> {
+        // First layer that has the key serves the slice. A layer that
+        // *has* the key but rejects the range (RangeNotSatisfiable)
+        // surfaces that error rather than masking it with a later layer.
+        for store in self.layers() {
+            match store.get_slice(key, range.clone()) {
+                Err(StoreError::NotFound) => continue,
+                other => return other,
+            }
+        }
+        Err(StoreError::NotFound)
+    }
+
+    fn head(&self, key: &K) -> Option<BlobInfo> {
+        self.layers().find_map(|s| s.head(key))
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.layers().any(|s| s.contains(key))
+    }
+
+    fn get_range(
+        &self,
+        key: &K,
+        range: ByteRange,
+    ) -> Result<Option<(Vec<u8>, ResolvedRange)>, StoreError> {
+        for store in self.layers() {
+            match store.get_range(key, range) {
+                Ok(None) => continue,
+                other => return other,
+            }
+        }
+        Ok(None)
+    }
+}
+
+/// Default size threshold (1 MiB): blobs `>=` this go to the large
+/// store, smaller ones to the small store.
+pub const DEFAULT_SIZE_THRESHOLD: u64 = 1 << 20;
+
+/// Routes writes by blob size; reads consult both layers.
+///
+/// `insert`/`put` send blobs of `threshold` bytes or larger to `large`
+/// and everything else to `small`. Reads check `small` first, then
+/// `large`. Typical wiring: `small` = SQLite (`WITHOUT ROWID`, native
+/// `substr` ranges), `large` = a raw loose-file store (OS page cache,
+/// cheap `pread`).
+pub struct SizeRouter<K> {
+    small: BlobStore<K>,
+    large: BlobStore<K>,
+    threshold: u64,
+}
+
+impl<K: Send + Sync> SizeRouter<K> {
+    /// Build a router with an explicit byte threshold.
+    pub fn new(small: BlobStore<K>, large: BlobStore<K>, threshold: u64) -> Self {
+        Self {
+            small,
+            large,
+            threshold,
+        }
+    }
+
+    /// Build a router with [`DEFAULT_SIZE_THRESHOLD`].
+    pub fn with_default_threshold(small: BlobStore<K>, large: BlobStore<K>) -> Self {
+        Self::new(small, large, DEFAULT_SIZE_THRESHOLD)
+    }
+
+    /// The store a blob of `len` bytes is written to.
+    fn route(&self, len: usize) -> &BlobStore<K> {
+        if len as u64 >= self.threshold {
+            &self.large
+        } else {
+            &self.small
+        }
+    }
+}
+
+impl<K: Send + Sync> ContentStore<K> for SizeRouter<K> {
+    fn put(&self, key: K, data: &[u8]) -> Result<(), StoreError> {
+        self.route(data.len()).put(key, data)
+    }
+
+    fn insert(&self, data: &[u8]) -> Result<K, StoreError> {
+        self.route(data.len()).insert(data)
+    }
+
+    fn get(&self, key: &K) -> Option<Vec<u8>> {
+        self.small.get(key).or_else(|| self.large.get(key))
+    }
+
+    fn get_slice(&self, key: &K, range: std::ops::Range<u64>) -> Result<Vec<u8>, StoreError> {
+        match self.small.get_slice(key, range.clone()) {
+            Err(StoreError::NotFound) => self.large.get_slice(key, range),
+            other => other,
+        }
+    }
+
+    fn head(&self, key: &K) -> Option<BlobInfo> {
+        self.small.head(key).or_else(|| self.large.head(key))
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.small.contains(key) || self.large.contains(key)
+    }
+
+    fn get_range(
+        &self,
+        key: &K,
+        range: ByteRange,
+    ) -> Result<Option<(Vec<u8>, ResolvedRange)>, StoreError> {
+        match self.small.get_range(key, range)? {
+            Some(hit) => Ok(Some(hit)),
+            None => self.large.get_range(key, range),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "memory"))]
+mod tests {
+    use super::*;
+    use crate::SharedMemoryStore;
+    use covalence_hash::O256;
+
+    fn mem() -> BlobStore<O256> {
+        BlobStore::new(SharedMemoryStore::new())
+    }
+
+    #[test]
+    fn overlay_reads_fall_through() {
+        let primary = mem();
+        let backing = mem();
+        let key = backing.insert(b"from backing").unwrap();
+
+        let overlay = OverlayStore::new(primary, vec![backing]);
+        assert_eq!(overlay.get(&key).unwrap(), b"from backing");
+        assert!(overlay.contains(&key));
+        assert_eq!(overlay.head(&key).unwrap().size, 12);
+    }
+
+    #[test]
+    fn overlay_primary_wins_and_writes_local() {
+        let primary = mem();
+        let backing = mem();
+        // Same content hashes identically in both layers; insert into the
+        // backing layer, then prove writes land in primary only.
+        let overlay = OverlayStore::new(primary.clone(), vec![backing.clone()]);
+        let key = overlay.insert(b"written").unwrap();
+        assert!(primary.contains(&key));
+        assert!(!backing.contains(&key));
+        assert_eq!(overlay.get(&key).unwrap(), b"written");
+    }
+
+    #[test]
+    fn overlay_miss_is_none() {
+        let overlay = OverlayStore::new(mem(), vec![mem()]);
+        let absent = O256::blob(b"nope");
+        assert!(overlay.get(&absent).is_none());
+        assert!(!overlay.contains(&absent));
+        assert!(matches!(
+            overlay.get_slice(&absent, 0..4),
+            Err(StoreError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn size_router_routes_by_size() {
+        let small = mem();
+        let large = mem();
+        let router = SizeRouter::new(small.clone(), large.clone(), 8);
+
+        let s = router.insert(b"tiny").unwrap(); // 4 bytes -> small
+        let l = router.insert(b"a much larger blob").unwrap(); // >=8 -> large
+
+        assert!(small.contains(&s) && !large.contains(&s));
+        assert!(large.contains(&l) && !small.contains(&l));
+
+        // Reads find both regardless of which layer holds them.
+        assert_eq!(router.get(&s).unwrap(), b"tiny");
+        assert_eq!(router.get(&l).unwrap(), b"a much larger blob");
+        assert_eq!(router.get_slice(&l, 0..1).unwrap(), b"a");
+    }
+}

--- a/crates/covalence/Cargo.toml
+++ b/crates/covalence/Cargo.toml
@@ -33,7 +33,7 @@ covalence-shell = { path = "../covalence-shell" }
 covalence-store = { path = "../covalence-store", features = ["sqlite"] }
 # covalence-git is gated off WASM: its `clone` feature transitively pulls
 # in libsqlite3-sys, whose sqlite3.c build needs a real WASI sysroot.
-covalence-git = { path = "../covalence-git", optional = true, features = ["clone"] }
+covalence-git = { path = "../covalence-git", optional = true, features = ["clone", "cog"] }
 covalence-hol = { path = "../covalence-hol", optional = true }
 covalence-opentheory = { path = "../covalence-opentheory", optional = true }
 covalence-wasm = { path = "../covalence-wasm", default-features = false }

--- a/crates/covalence/src/cmd/cog.rs
+++ b/crates/covalence/src/cmd/cog.rs
@@ -14,6 +14,9 @@ pub enum CogCommand {
     /// Clone a git repository into a covalence store
     Clone(CloneArgs),
 
+    /// Inspect or populate the per-repo cog store under `.git/cog-<uuid>/`
+    Store(StoreArgs),
+
     /// Mount a tree object (by O256 hash) as a read-only FUSE filesystem
     ///
     /// Linux-only scaffold. No range requests; reading a large file pulls
@@ -113,6 +116,46 @@ pub struct CloneArgs {
     pub store: Option<std::path::PathBuf>,
 }
 
+/// Inspect or populate the per-repo cog store under `.git/cog-<uuid>/`.
+#[derive(clap::Args)]
+pub struct StoreArgs {
+    #[command(subcommand)]
+    pub command: Option<StoreCommand>,
+
+    /// Route large blobs (>= threshold bytes) to the BLAKE3 loose store;
+    /// small blobs stay in SQLite. Reads consult both layers.
+    #[arg(long, global = true)]
+    pub routed: bool,
+
+    /// Size threshold in bytes for `--routed` (default 1 MiB).
+    #[arg(long, global = true)]
+    pub threshold: Option<u64>,
+}
+
+#[derive(Subcommand)]
+pub enum StoreCommand {
+    /// Show the resolved cog-store paths (the default).
+    Info,
+
+    /// Insert files into the store, printing each blob's BLAKE3 (O256).
+    Add(StoreAddArgs),
+
+    /// Write a blob (by O256 hex) to stdout.
+    Cat(StoreCatArgs),
+}
+
+#[derive(clap::Args)]
+pub struct StoreAddArgs {
+    /// Files to insert.
+    pub paths: Vec<std::path::PathBuf>,
+}
+
+#[derive(clap::Args)]
+pub struct StoreCatArgs {
+    /// O256 hex (64 chars) of the blob to read.
+    pub hash: String,
+}
+
 pub fn run(args: CogArgs) {
     match args.command {
         None => println!("cogit {} ({})", covalence_git::VERSION, covalence::TARGET),
@@ -124,6 +167,12 @@ pub fn run(args: CogArgs) {
         }
         Some(CogCommand::Clone(args)) => {
             if let Err(e) = run_clone(args) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+        Some(CogCommand::Store(args)) => {
+            if let Err(e) = run_store(args) {
                 eprintln!("{e}");
                 std::process::exit(1);
             }
@@ -262,6 +311,78 @@ fn push_to_server(
     }
     println!("Pushed {} blob(s) and {} tree(s)", blobs.len(), trees.len());
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// cov cog store — per-repo cog store under .git/cog-<uuid>/
+// ---------------------------------------------------------------------------
+
+fn run_store(args: StoreArgs) -> std::io::Result<()> {
+    use covalence_git::cog::CogStoreDir;
+    use covalence_store::ContentStore;
+
+    let dir = CogStoreDir::discover()?.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no git repository found in the current directory or any ancestor",
+        )
+    })?;
+
+    match args.command.unwrap_or(StoreCommand::Info) {
+        StoreCommand::Info => {
+            println!("cog store: {}", dir.dir().display());
+            println!("  db:      {}", dir.db_path().display());
+            println!("  objects: {}", dir.objects_dir().display());
+            println!(
+                "  mode:    {}",
+                if args.routed { "routed" } else { "sqlite" }
+            );
+            if !dir.dir().exists() {
+                println!("  (not yet created — `cog store add` initializes it)");
+            }
+            Ok(())
+        }
+        StoreCommand::Add(add) => {
+            let store = open_store(&dir, args.routed, args.threshold)?;
+            for path in &add.paths {
+                let data = std::fs::read(path)
+                    .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {e}", path.display())))?;
+                let key = store
+                    .insert(&data)
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                println!("{key}  {}", path.display());
+            }
+            Ok(())
+        }
+        StoreCommand::Cat(cat) => {
+            use std::io::Write;
+            let key = covalence_store::O256::from_hex(&cat.hash).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("invalid O256 hex: {}", cat.hash),
+                )
+            })?;
+            let store = open_store(&dir, args.routed, args.threshold)?;
+            let data = store.get(&key).ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::NotFound, format!("not in store: {key}"))
+            })?;
+            std::io::stdout().write_all(&data)
+        }
+    }
+}
+
+/// Open the cog store, optionally size-routed (SQLite + BLAKE3 loose).
+fn open_store(
+    dir: &covalence_git::cog::CogStoreDir,
+    routed: bool,
+    threshold: Option<u64>,
+) -> std::io::Result<covalence_store::BlobStore<covalence_store::O256>> {
+    let result = if routed {
+        dir.open_routed(threshold.unwrap_or(covalence_store::DEFAULT_SIZE_THRESHOLD))
+    } else {
+        dir.open_default()
+    };
+    result.map_err(|e| std::io::Error::other(e.to_string()))
 }
 
 fn run_hash_blob(args: HashBlobArgs) -> std::io::Result<()> {

--- a/docs/design/proposals/cog-git-store/README.md
+++ b/docs/design/proposals/cog-git-store/README.md
@@ -1,0 +1,450 @@
+# Cog Git Store — dogfooding cog to serve test assets
+
+> **STATUS: SKETCH.** Not built. A staged plan for a zero-install,
+> per-repo content store that lives *inside* an existing `.git`
+> directory, indexes the surrounding git repo, spills large blobs to a
+> BLAKE3 loose-object store, and lazily fetches missing hashes from
+> remote URLs (file or git) — caching them on the way through. The
+> first consumer is the test suite: dogfood cog to serve fixtures, and
+> eventually fetch large corpora like `set.mm` and check them with
+> `covalence-metamath`.
+>
+> This is the **native, hard-wired precursor** to
+> [`../wasm-store-composition/`](../wasm-store-composition/): the
+> combined store here is exactly a `wraps`/`depends_on` graph (see
+> [`StoreManifest`][manifest]), assembled in Rust instead of out of WASM
+> components. It also makes concrete the "store sits outside the kernel
+> TCB as an oracle" stance from
+> [`../layered-framework/04-store.md`](../layered-framework/04-store.md).
+
+## 0. The one idea
+
+A repo already carries a content-addressed object database under
+`.git`. We add a **sibling** database next to it — keyed by BLAKE3
+(`O256`) instead of git's SHA — and teach cog to read through both as a
+single store, falling back to remote sources and caching what it pulls.
+Nothing is installed globally; nothing lands in the working tree;
+deleting the directory loses only cache, never source of truth.
+
+```
+worktree/
+  .git/
+    objects/                         ← git's own ODB (SHA-1 / SHA-256)
+    cog-14169d9d-e25f-46dd-abc7-dd53b495cd06/   ← THE cog store dir
+      store.db        SQLite ContentStore<O256>      (small blobs)   [§1]
+      objects/        BLAKE3 loose store  ab/cdef…   (large blobs)   [§3]
+      index.db        git-OID ⇄ O256 index            (or in store.db)[§2]
+      sources.json    remote upstreams + url→hash cache             [§4]
+      manifest.json   StoreManifest describing the combined graph   [opt]
+```
+
+### Why under `.git`, and why a UUID suffix
+
+- **Auto-ignored.** Git never tracks anything under `.git`, so the
+  store never shows in `git status`, never gets committed, never
+  pollutes the working tree. No `.gitignore` edit required.
+- **Travels with the gitdir.** It rides along with the repository's
+  real git directory and is naturally shared across linked worktrees
+  (we anchor it at the **commondir**, §0.1).
+- **Zero install.** No global state, no daemon required, no XDG
+  directory to provision. The store's lifetime is the repo's.
+- **The UUID is the well-known marker.** A bare `.git/cog` risks
+  colliding with some future git feature or another tool named "cog".
+  A fixed UUID suffix makes the directory an unmistakable, greppable,
+  collision-proof signature that *this* is a covalence cog store:
+
+  ```rust
+  /// The one well-known cog-store directory UUID. Never changes.
+  pub const COG_STORE_UUID: &str = "14169d9d-e25f-46dd-abc7-dd53b495cd06";
+  pub const COG_STORE_DIRNAME: &str = "cog-14169d9d-e25f-46dd-abc7-dd53b495cd06";
+  ```
+
+### 0.1 Locating the directory
+
+Discovery reuses the existing, dependency-free walker
+[`covalence_proto::git::discover_git_repo`][discover] →
+`DiscoveredRepo { root, bare }`. The store dir is anchored at the
+**commondir**, not the per-worktree gitdir, so every linked worktree
+shares one cache:
+
+- **Worktree:** `.git` is a directory → store at
+  `<root>/.git/cog-<uuid>/`. `.git` is a *file* (linked worktree
+  pointer `gitdir: …`) → resolve to the commondir and put the store
+  there. The gitdir/commondir resolution already exists in
+  [`covalence-git/src/clone/local.rs`][local] (it handles
+  worktree-pointer `.git` files and `commondir`); factor that out and
+  reuse it.
+- **Bare repo:** `root` *is* the gitdir → `<root>/cog-<uuid>/`.
+
+```rust
+/// Handle to a cog store directory inside a git repo. Pure path logic;
+/// opening backends is separate so callers pick which layers they want.
+pub struct CogStoreDir { dir: PathBuf }
+
+impl CogStoreDir {
+    /// Walk up from `cwd`, resolve the commondir, return the store dir
+    /// (does not create it).
+    pub fn discover() -> io::Result<Option<Self>>;
+    /// Anchor at an already-resolved git common directory.
+    pub fn at_commondir(commondir: &Path) -> Self;
+    pub fn create(&self) -> io::Result<()>;        // mkdir -p
+    pub fn db_path(&self) -> PathBuf;              // dir/store.db
+    pub fn objects_dir(&self) -> PathBuf;          // dir/objects
+    pub fn sources_path(&self) -> PathBuf;         // dir/sources.json
+}
+```
+
+**Where the code lives.** Recommend a new `cog` module in
+**`covalence-git`** behind a `cog` feature (`cog = ["sqlite",
+"object-store"]`) — it already owns git layout, `GitStore`,
+`LooseBackend`, and `LfsStore`. Repo discovery stays the caller's job
+(the CLI already depends on `covalence-proto`), so `covalence-git` need
+not gain a `covalence-proto` edge: pass a resolved path in. If the
+module outgrows that home, extract a `covalence-cog` crate later.
+
+### 0.2 The opinionated default (start here)
+
+The minimum viable store is **just `store.db`** — a
+[`SqliteStore`][sqlite] opened at `db_path()`, wrapped in a
+`BlobStore<O256>`. This is the foundation everything else layers onto,
+and it is a one-function helper:
+
+```rust
+impl CogStoreDir {
+    /// Open (creating if absent) the default cog store: a single SQLite
+    /// ContentStore<O256> at `store.db`.
+    pub fn open_sqlite(&self) -> Result<SqliteStore, StoreError>;
+    pub fn open_default(&self) -> Result<BlobStore<O256>, StoreError> {
+        self.create()?;
+        Ok(BlobStore::new(self.open_sqlite()?))
+    }
+}
+```
+
+CLI wiring mirrors the existing [`resolve_store`][resolve] in
+`cmd/mod.rs`: when no explicit `--store` is given, a new cog-aware
+default discovers the repo and opens `.git/cog-<uuid>/store.db` instead
+of falling back to in-memory. (`cov serve --store` already resolves a
+default DB path via [`default_store_path()`][cfg] — the cog store is
+the *repo-scoped* analogue.)
+
+Everything below is additive: each step wraps the previous store in one
+more layer of the read-fallback / write-routing graph.
+
+---
+
+## 1. Step 1 — index the git repo into a combined store
+
+**Goal.** Read a blob by its BLAKE3 hash and have it served from *either*
+the cog SQLite DB *or* the surrounding git ODB, transparently.
+
+### 1.1 The missing primitive: an overlay/fallback combinator
+
+`covalence-store` has wrappers (`BlobStore`, `GitPrefixStore`,
+`KeyedObjectStore`) but **no read-fallback / write-routing combinator**.
+Add one — it is the generic shape the rest of this proposal assembles:
+
+```rust
+/// Reads try each layer in order; the first hit wins. Writes go to the
+/// single writable `primary`. Mirrors StoreManifest `depends_on`: the
+/// store can ride out a missing upstream.
+pub struct OverlayStore<K> {
+    primary: BlobStore<K>,        // writable, checked first
+    fallbacks: Vec<BlobStore<K>>, // read-only, checked in order
+}
+
+impl<K: Send + Sync + Clone> ContentStore<K> for OverlayStore<K> {
+    fn get(&self, k: &K) -> Option<Vec<u8>> { /* primary, then fallbacks */ }
+    fn get_slice(&self, k: &K, r: Range<u64>) -> Result<Vec<u8>, StoreError> { /* first hit */ }
+    fn head(&self, k: &K) -> Option<BlobInfo> { /* first hit */ }
+    fn contains(&self, k: &K) -> bool { /* any layer */ }
+    fn insert(&self, d: &[u8]) -> Result<K, StoreError> { self.primary.insert(d) }
+    fn put(&self, k: K, d: &[u8]) -> Result<(), StoreError> { self.primary.put(k, d) }
+}
+```
+
+`get_slice`/`head` range-fallthrough composes cleanly with SQLite's
+native `substr` reads and (later) the loose store's `pread`. This type
+belongs in `covalence-store` (behind no extra feature) so every consumer
+gets it.
+
+### 1.2 Indexing: git OID ⇄ O256
+
+Git objects are keyed by SHA; the cog store is keyed by BLAKE3. To read
+a git-stored file *by its content hash*, we need a mapping. The
+machinery already exists in [`covalence-git`'s `GitStore`][gitstore]
+(`git_objects: git_oid → blob_hash`, `blobs: o256 → data`,
+`cov_trees`) — but that copies data into SQLite. For indexing an
+*existing* repo we want a **lazy** index that maps without copying:
+
+```sql
+-- in store.db (or a sibling index.db)
+CREATE TABLE IF NOT EXISTS git_index (
+    o256    BLOB PRIMARY KEY,   -- O256::blob(raw_content)
+    git_oid BLOB NOT NULL,      -- git object id (read lazily from ODB)
+    kind    TEXT NOT NULL       -- "blob" | "tree" | "commit" | "tag"
+) WITHOUT ROWID;
+```
+
+**Indexer.** Enumerate git objects via
+[`OdbBackend::iter_oids`][odb] (loose **and** packed), read each, and
+for **blobs** record `O256::blob(raw_content) → oid`. Asset serving is
+about file *content*, so we key blobs by the BLAKE3 of their raw bytes —
+the same hash `cov cog hash-blob --blake3` and `SqliteStore::insert`
+produce, so a file's identity is stable across cog and git. (Trees and
+commits are git-structured; indexing them is a later extension and is
+not needed for serving assets.)
+
+```rust
+pub fn index_git_repo(store: &CogStoreDir, repo: &Path) -> Result<IndexStats, StoreError>;
+```
+
+`--global` may target the XDG store ([`default_store_path()`][cfg])
+instead of the repo-local DB, and the overlay can even chain repo-local
+over global.
+
+### 1.3 The combined store
+
+```rust
+/// Reads:  cog SQLite  →  git ODB (via git_index)
+/// Writes: cog SQLite
+pub fn combined_store(dir: &CogStoreDir, repo: &Path)
+    -> Result<BlobStore<O256>, StoreError>;
+```
+
+The git layer is an `OdbBackend` wrapped in a small
+`ContentStore<O256>` adapter that, on `get(o256)`, looks up `git_index`
+→ `oid` → reads the object bytes from the ODB. Misses fall through (to
+§3's loose store, then §4's remote fetch).
+
+**Deliverables:** `OverlayStore` in `covalence-store`; `git_index`
+table + indexer + ODB-by-O256 adapter in `covalence-git`;
+`cov cog index [--global]` CLI command.
+
+---
+
+## 2. Step 2 — BLAKE3 loose object store for large blobs
+
+**Goal.** Keep SQLite lean: small blobs in the DB, large blobs as loose
+files. Big goes to the loose store, small to SQLite — now a **triple**
+combined store (SQLite + loose + git-ODB).
+
+### 2.1 The loose store
+
+[`LfsStore`][lfs] is *already* a `ContentStore<O256>` that writes raw,
+uncompressed bytes into a git-style fanout (`aa/bb/<full>`) keyed by a
+256-bit hash — it just uses SHA-256 (`O256::blob_sha256`). Step 2 is
+"`LfsStore`, but keyed by BLAKE3 (`O256::blob`)". Two ways:
+
+- **(Recommended) Generalize the loose store over its hash function.**
+  Parameterize the existing fanout store by a `HashCtx` / hash-fn so
+  the same code backs both the SHA-256 LFS store and a BLAKE3 cog loose
+  store. One fanout level (`ab/<rest>`, git-style) keeps it familiar;
+  raw bytes (no zlib) keep `pread` range reads cheap.
+- Or add a sibling `Blake3LooseStore` if generalizing churns LFS too
+  much.
+
+```rust
+pub struct Blake3LooseStore { dir: PathBuf }   // dir/ab/cdef… raw bytes
+impl ContentStore<O256> for Blake3LooseStore {
+    // get_slice via pread; head via file length; insert hashes with O256::blob
+}
+```
+
+### 2.2 Size-routing writes
+
+```rust
+/// Routes inserts by size; reads check both. Default threshold 1 MiB.
+pub struct SizeRouter<K> { small: BlobStore<K>, large: BlobStore<K>, threshold: u64 }
+```
+
+`insert(data)`: `data.len() >= threshold` → loose (`large`), else SQLite
+(`small`). Reads consult both. The full read order becomes:
+
+```
+cog SQLite  →  cog BLAKE3 loose  →  git ODB (index)   [→ §4 remote]
+```
+
+**Rationale.** SQLite (`WITHOUT ROWID`, `substr` ranges) is excellent
+for many small blobs but bloats and slows under large BLOBs and fat WAL
+frames; loose files get OS page-cache, cheap `pread`, and drop-in LFS
+compatibility. Threshold is config (`sources.json` / `manifest.json`).
+
+**Deliverables:** generalized loose store (BLAKE3 variant) + `SizeRouter`
+in `covalence-store`; wire both into `combined_store`.
+
+---
+
+## 3. Step 3 — fetch hash-first, URL-second, cache the result
+
+**Goal.** `cov cog fetch` resolves a hash from the cog store first; on a
+miss, fetches from a URL (file or git), verifies, and **caches into the
+cog store** so the next lookup is local.
+
+```rust
+/// Resolution order:
+///   1. combined cog store (SQLite → loose → git index)
+///   2. each configured URL source, in order
+/// On a remote hit: verify (if an expected hash was given), then insert
+/// into the cog store (size-routed) and record provenance.
+pub fn fetch(store: &CombinedStore, want: FetchRequest) -> Result<O256, FetchError>;
+
+pub struct FetchRequest {
+    pub hash: Option<O256>,   // content address to satisfy
+    pub url: Option<String>,  // where to get it if missing
+    pub expect: Option<O256>, // verify fetched bytes against this
+}
+```
+
+CLI:
+
+```sh
+cov cog fetch <hash>                       # cog store only; error if absent
+cov cog fetch <url>                        # fetch+cache; print the O256
+cov cog fetch <url> --expect <hash>        # fetch, verify, cache
+cov cog fetch <hash> --from <url>          # try local; fall back to url
+```
+
+### 3.1 Caching = the store is the cache
+
+The cog store *is* the cache (`depends_on` upstreams, per
+[`StoreManifest`][manifest]). `sources.json` records provenance so
+re-fetching is cheap and auditable:
+
+```jsonc
+{
+  "threshold_bytes": 1048576,
+  "sources": [ { "name": "metamath", "url": "https://…", "kind": "file" } ],
+  "url_cache": { "https://…/set.mm": "<o256-hex>" }   // url → content hash
+}
+```
+
+### 3.2 Stages
+
+| Stage | Scope | Builds on |
+|-------|-------|-----------|
+| **3a** | Plain file URLs (`http`/`https`/`file`) via `ureq`, content-addressed cache, optional `--expect` verify. *Smallest slice; unblocks `set.mm`.* | [`covalence-opentheory::fetch_url`][otfetch] template |
+| **3b** | Provenance + `url_cache` tables; conditional GET (ETag / `Last-Modified`) so a known URL revalidates instead of re-downloading. | 3a |
+| **3c** | **Git repo URLs** (`<repo>@<ref>:<path>`): use the existing smart-HTTP-v2 clone ([`covalence-git::clone`][clone], `CloneSource::Http`/`Local`) into the cog `GitStore`, then resolve `path@ref` → blob `O256`. Partial clone (`blob:none`) to fetch a single blob. | §1 index, clone |
+| **3d** | Federated sources: multiple upstreams / mirrors with ordered fallback + retry (the `depends_on` list). | 3a–3c |
+
+"The URL can be a git repo or just a regular file URL" → **3a** (file) +
+**3c** (git). Plain files cover `set.mm` directly; the git path gives
+reproducible, ref-pinned fetches.
+
+**Deliverables:** `cov cog fetch` command + `fetch()` function;
+`sources.json` read/write; gate outbound HTTP behind a `fetch` feature
+(matching `covalence-repl` / `covalence-opentheory`).
+
+---
+
+## 4. Step 4 — `set.mm` fetch-and-check test
+
+**Goal.** An integration test that fetches `set.mm` from a URL into a
+cog store and checks it with [`covalence-metamath`][mm] — opt-in, so
+default CI stays fast.
+
+### 4.1 Shape
+
+`crates/covalence-metamath/tests/setmm_fetch.rs`:
+
+1. Create a cog store in a temp dir (or a stable, reused cache dir so CI
+   downloads once).
+2. `fetch()` `set.mm` from a pinned source (§3a file URL, or §3c git
+   ref for reproducibility) into the store.
+3. Parse with `covalence_metamath::parse` (its `FileResolver` already
+   handles `$[ … $]` includes), then `verify_all` / a bounded subset of
+   `verify_proof`.
+
+### 4.2 Make it disableable — two layers (house pattern)
+
+The codebase gates optional tests by **feature flag** (compile-time) +
+**env var** (runtime); it does **not** use `#[ignore]`.
+
+- **Compile gate:** `#![cfg(feature = "fetch")]` on the test (no
+  outbound HTTP in a default build).
+- **Runtime gate:** require `COV_TEST_SETMM=1` to run; otherwise return
+  early (skip). Mirrors `covalence-llm`'s `COV_LLM_MODEL` env reads.
+- **Knobs:** `COV_TEST_SETMM_URL` (override source),
+  `COV_TEST_SETMM_FULL=1` (full `verify_all` vs. a bounded prefix —
+  full set.mm verification is minutes-long and tens of MB).
+- **Reproducibility:** pin a specific `metamath/set.mm` commit/tag (via
+  §3c) and/or an `--expect` BLAKE3, so the test is deterministic. The
+  cog store doubles as the download cache across runs.
+
+```rust
+#![cfg(feature = "fetch")]
+#[test]
+fn setmm_fetch_and_verify() {
+    if std::env::var("COV_TEST_SETMM").is_err() { return; } // opt-in
+    // … open temp cog store, fetch set.mm, parse, verify (bounded unless _FULL)
+}
+```
+
+### 4.3 Forward hook
+
+"We'll be adding metamath import support to `covalence-core` shortly."
+The test starts against `covalence-metamath`'s own `verify_all`; once
+core import lands, add a second assertion that the imported terms
+type-check in the kernel. Keep both behind the same gates.
+
+**Deliverables:** opt-in `setmm_fetch` test; `fetch` feature on
+`covalence-metamath` (dev-dependency on the cog/fetch path); a note in
+the [PR checklist][claude] that `COV_TEST_SETMM` is off by default.
+
+---
+
+## 5. Build order
+
+1. **§0.2** `CogStoreDir` + `open_default()` — the SQLite-only default
+   under `.git/cog-<uuid>/`. Wire into the CLI's `resolve_store`.
+2. **§1.1** `OverlayStore` in `covalence-store` (generic, reusable).
+3. **§1.2–1.3** `git_index` + indexer + ODB-by-O256 adapter +
+   `cov cog index`.
+4. **§2** generalized BLAKE3 loose store + `SizeRouter` → triple store.
+5. **§3a** `cov cog fetch` for file URLs + content-addressed cache.
+6. **§3b–3d** provenance/url-cache, conditional GET, git-URL fetch,
+   federation — as needed.
+7. **§4** opt-in `set.mm` test.
+
+Steps 1–2 are independently useful (faster, repo-local test fixtures)
+before any network code exists.
+
+## 6. Open questions
+
+1. **Code home.** `cog` module in `covalence-git` (recommended) vs. a
+   new `covalence-cog` crate. Start in-crate; extract if it grows.
+2. **Keyspace.** Blobs keyed by raw-content BLAKE3 (asset model,
+   recommended) vs. git-framed bytes. Keep `GitStore.git_objects` for
+   git-native lookups; `git_index` for content lookups.
+3. **Overlay placement.** `OverlayStore`/`SizeRouter` as first-class
+   `covalence-store` combinators (recommended) vs. ad-hoc in
+   `covalence-git`. The former benefits every consumer and matches the
+   `StoreManifest` graph.
+4. **Concurrency.** Multiple `cov` processes / worktrees sharing one
+   store. SQLite WAL + busy-timeout (already in `covalence-sqlite`) and
+   atomic temp+rename in the loose store (already in `LooseBackend`)
+   cover most of it; document the contract.
+5. **GC / pruning.** The cache grows unbounded. A `cov cog gc`
+   (size-capped LRU over the loose store + url_cache) is a later add.
+6. **Manifest.** Emit a `manifest.json` ([`StoreManifest`][manifest])
+   describing the assembled graph, so the store self-describes and the
+   future WASM-component composition
+   ([`../wasm-store-composition/`](../wasm-store-composition/)) can adopt
+   it unchanged.
+
+---
+
+[manifest]: ../../../../crates/covalence-store/src/metadata.rs
+[sqlite]: ../../../../crates/covalence-store/src/sqlite.rs
+[resolve]: ../../../../crates/covalence/src/cmd/mod.rs
+[cfg]: ../../../../crates/covalence-proto/src/config.rs
+[discover]: ../../../../crates/covalence-proto/src/git.rs
+[local]: ../../../../crates/covalence-git/src/clone/local.rs
+[gitstore]: ../../../../crates/covalence-git/src/store/sqlite_store.rs
+[odb]: ../../../../crates/covalence-git/src/store/odb.rs
+[lfs]: ../../../../crates/covalence-git/src/lfs.rs
+[clone]: ../../../../crates/covalence-git/src/clone/mod.rs
+[otfetch]: ../../../../crates/covalence-opentheory/src/fetch.rs
+[mm]: ../../../../crates/covalence-metamath/src/lib.rs
+[claude]: ../../../../CLAUDE.md

--- a/docs/design/proposals/cog-git-store/README.md
+++ b/docs/design/proposals/cog-git-store/README.md
@@ -1,6 +1,12 @@
 # Cog Git Store — dogfooding cog to serve test assets
 
-> **STATUS: SKETCH.** Not built. A staged plan for a zero-install,
+> **STATUS: IN PROGRESS — foundation landed.** The §0 default
+> (`CogStoreDir` + SQLite store under `.git/cog-<uuid>/`), the §1.1
+> `OverlayStore`/`SizeRouter` combinators, and the §2 BLAKE3
+> `Blake3LooseStore` are implemented and tested, wired through
+> `cov cog store {info,add,cat} [--routed]`. Still to do: §1.2–1.3 git
+> indexing, §3 `cov cog fetch`, §4 the `set.mm` test. A staged plan for a
+> zero-install,
 > per-repo content store that lives *inside* an existing `.git`
 > directory, indexes the surrounding git repo, spills large blobs to a
 > BLAKE3 loose-object store, and lazily fetches missing hashes from
@@ -396,12 +402,17 @@ the [PR checklist][claude] that `COV_TEST_SETMM` is off by default.
 
 ## 5. Build order
 
-1. **§0.2** `CogStoreDir` + `open_default()` — the SQLite-only default
-   under `.git/cog-<uuid>/`. Wire into the CLI's `resolve_store`.
-2. **§1.1** `OverlayStore` in `covalence-store` (generic, reusable).
-3. **§1.2–1.3** `git_index` + indexer + ODB-by-O256 adapter +
-   `cov cog index`.
-4. **§2** generalized BLAKE3 loose store + `SizeRouter` → triple store.
+1. **[done] §0.2** `CogStoreDir` + `open_default()` — the SQLite-only
+   default under `.git/cog-<uuid>/` (commondir-anchored), exposed as
+   `cov cog store`.
+2. **[done] §1.1** `OverlayStore` + `SizeRouter` in `covalence-store`
+   (generic, reusable).
+3. **[done] §2** `Blake3LooseStore` + `SizeRouter` wiring →
+   `cov cog store --routed` (SQLite + loose). *(BLAKE3 loose store added
+   as a sibling to `LfsStore` rather than generalizing it; revisit if a
+   shared generic loose store proves worthwhile.)*
+4. **[next] §1.2–1.3** `git_index` + indexer + ODB-by-O256 adapter +
+   `cov cog index`; fold the git layer into the overlay → triple store.
 5. **§3a** `cov cog fetch` for file URLs + content-addressed cache.
 6. **§3b–3d** provenance/url-cache, conditional GET, git-URL fetch,
    federation — as needed.


### PR DESCRIPTION
Add a staged design proposal for a zero-install, per-repo content store
living under .git/cog-<well-known-uuid>/:

- §0  opinionated default: a SQLite ContentStore<O256> at store.db,
      anchored at the git commondir (shared across worktrees)
- §1  index the surrounding git ODB and read through both via a new
      OverlayStore read-fallback/write-routing combinator
- §2  BLAKE3 loose object store for large blobs (generalizing LfsStore)
      with a SizeRouter -> triple combined store
- §3  cov cog fetch: hash-first, URL-second (file or git), cache into
      the store; staged 3a-3d
- §4  opt-in set.mm fetch-and-check test against covalence-metamath,
      gated by feature + env var (house pattern)

Grounded in existing APIs (ContentStore, SqliteStore, GitStore,
LfsStore, OdbBackend, StoreManifest, discover_git_repo, covalence-metamath).