### PR TITLE
hol: sketch the surface-syntax AST (pure S-expr, term sublanguage)

### DIFF
--- a/SKELETONS.md
+++ b/SKELETONS.md
@@ -23,8 +23,8 @@ it is how unfinished work stays discoverable.
   implemented, but the layers above remain stubs: the **elaborator** (surface
   → low-level S-expr → kernel object), the **`#by` tactic grammar** (proof
   steps are kept as raw `SExpr`s in `Proof::steps`), and **`#import` content
-  addressing** (`ImportTarget::Hash` is parsed but not resolved) are all future
-  work.
+  addressing** (`#import` resolves names only; by-hash addressing is unbuilt)
+  are all future work.
 
 ## Postulates pending proof
 

--- a/SKELETONS.md
+++ b/SKELETONS.md
@@ -16,6 +16,15 @@ it is how unfinished work stays discoverable.
   will land here as the HOL-on-store stack comes online. See the
   `covalence-kernel` crate-root docs and `docs/roadmap.md`.
 
+- **`crates/covalence-hol/src/surface/`** — design sketch of the surface
+  syntax (the "generalized Haskell" authoring layer, `docs/surface-syntax.md`).
+  The AST (`surface::ast`) and the `#`-builtin registry (`surface::Builtin`)
+  are sketched, but `surface::parse` is a stub returning
+  `SurfaceError::NotImplemented` — the lowering from `covalence_sexp::SExpr`
+  to the directive AST is unwritten, and the elaborator (surface → low-level
+  S-expr → kernel object), the `#by` tactic grammar, and `#import` content
+  addressing are all future work.
+
 ## Postulates pending proof
 
 - **The `int` ordered-ring theory** in

--- a/SKELETONS.md
+++ b/SKELETONS.md
@@ -18,12 +18,13 @@ it is how unfinished work stays discoverable.
 
 - **`crates/covalence-hol/src/surface/`** — design sketch of the surface
   syntax (the "generalized Haskell" authoring layer, `docs/surface-syntax.md`).
-  The AST (`surface::ast`) and the `#`-builtin registry (`surface::Builtin`)
-  are sketched, but `surface::parse` is a stub returning
-  `SurfaceError::NotImplemented` — the lowering from `covalence_sexp::SExpr`
-  to the directive AST is unwritten, and the elaborator (surface → low-level
-  S-expr → kernel object), the `#by` tactic grammar, and `#import` content
-  addressing are all future work.
+  The AST (`surface::ast`), the `#`-builtin registry (`surface::Builtin`), and
+  the parser (`surface::parse` / `parse_str`, pure S-expr → directive AST) are
+  implemented, but the layers above remain stubs: the **elaborator** (surface
+  → low-level S-expr → kernel object), the **`#by` tactic grammar** (proof
+  steps are kept as raw `SExpr`s in `Proof::steps`), and **`#import` content
+  addressing** (`ImportTarget::Hash` is parsed but not resolved) are all future
+  work.
 
 ## Postulates pending proof
 

--- a/crates/covalence-hol/src/lib.rs
+++ b/crates/covalence-hol/src/lib.rs
@@ -16,6 +16,11 @@
 //! 3. **Term/type serialisation** ([`hash`], [`sexp`]) — content
 //!    hashing and the canonical S-expression syntax.
 //!
+//! 4. **Surface syntax** ([`surface`]) — a *design sketch* of the
+//!    high-level "generalized Haskell" authoring language (pure
+//!    S-expressions, `#`-headed builtins) that will elaborate down to the
+//!    kernel objects. See `docs/surface-syntax.md`.
+//!
 //! Nothing in this crate is consumed by `covalence-core`'s inference
 //! rules.
 
@@ -29,6 +34,7 @@ pub mod proofs;
 pub mod ring;
 pub mod semiring;
 pub mod sexp;
+pub mod surface;
 pub mod traits;
 pub mod types;
 

--- a/crates/covalence-hol/src/surface/ast.rs
+++ b/crates/covalence-hol/src/surface/ast.rs
@@ -1,0 +1,349 @@
+//! Abstract syntax for the surface language (**DESIGN SKETCH**).
+//!
+//! Every node here corresponds to a *pure* S-expression: there is **no
+//! infix syntax**. The prose sugar used in [`docs/surface-syntax.md`] —
+//! `'a -> 'b`, `none : option 'a`, `lhs => rhs` — is purely a convenience
+//! for human readers; the real, parseable forms are the `#`-headed
+//! builtins captured here (`(#fn 'a 'b)`, `(#sig none (option 'a))`,
+//! `(#rw lhs rhs)`).
+//!
+//! Three lexical name classes (see [`Name::class`]):
+//!
+//! - **builtins** start with `#` — every reserved keyword of the language
+//!   (directive heads *and* term/type form heads): `#theory`, `#fn`,
+//!   `#lam`, `#eq`, …
+//! - **type variables** start with `'` — `'a`, `'b`, …
+//! - everything else is an ordinary **name**: either a *dotted catalogue*
+//!   reference into the `defs/` catalogue (`coprod.case`, `option.some`,
+//!   `unit.nil`) or a *local* name (a bound variable, or a symbol the
+//!   surrounding `#theory` declares — `option`, `some`, `e`, `f`).
+//!
+//! [`docs/surface-syntax.md`]: ../../../../docs/surface-syntax.md
+
+use bytes::Bytes;
+use covalence_types::Int;
+use smol_str::SmolStr;
+
+// ============================================================================
+// Names
+// ============================================================================
+
+/// A surface identifier, classified by its lexical shape (see
+/// [`Name::class`]). Stored verbatim — the leading `#` / `'` (if any) is
+/// kept so the token round-trips.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Name(pub SmolStr);
+
+/// The lexical class a [`Name`] falls into. The class is a pure function
+/// of the spelling, so the parser can route a token without any scope
+/// information; binding resolution (is this *local* name a bound variable
+/// or a theory-declared constant?) is the elaborator's job, later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NameClass {
+    /// Starts with `#` — a reserved builtin keyword.
+    Builtin,
+    /// Starts with `'` — a type variable.
+    TyVar,
+    /// Contains a `.` and is not a builtin — a dotted reference into the
+    /// `defs/` catalogue (`nat.add`, `coprod.case`).
+    Catalogue,
+    /// Anything else — a bound variable or a locally-declared symbol.
+    Local,
+}
+
+impl Name {
+    /// Classify this name purely from its spelling.
+    pub fn class(&self) -> NameClass {
+        let s = self.0.as_str();
+        if s.starts_with('#') {
+            NameClass::Builtin
+        } else if s.starts_with('\'') {
+            NameClass::TyVar
+        } else if s.contains('.') {
+            NameClass::Catalogue
+        } else {
+            NameClass::Local
+        }
+    }
+
+    /// View as a string slice.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+// ============================================================================
+// Kinds & types
+// ============================================================================
+
+/// A **kind** classifies type formers. The only base kind is `#ty` (the
+/// kind of proper types); a type former such as `option` has kind
+/// `(#fn #ty #ty)`.
+///
+/// Kinds appear only in `#tydecl`. In the sketch's `(#tydecl (option 'a
+/// #ty))` the `'a` is a placeholder type parameter and the trailing `#ty`
+/// is the *result* kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Kind {
+    /// `#ty` — the kind of proper types.
+    Ty,
+    /// `(#fn k1 k2 … kn)` — the kind of an `n-1`-ary type former. Curried,
+    /// like [`Ty::Fn`].
+    Fn(Vec<Kind>),
+}
+
+/// A surface **type** expression. Pure S-expressions throughout: the
+/// arrow `'a -> 'b` is written `(#fn 'a 'b)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Ty {
+    /// `'a` — a type variable.
+    Var(SmolStr),
+    /// `#prop` — the type of propositions (the kernel's `prop`).
+    Prop,
+    /// `#bytes` — the type of `#blob` literals (the kernel's `bytes`).
+    Bytes,
+    /// `(#fn A B … Z)` — the curried function type `A -> B -> … -> Z`.
+    /// Always at least two elements.
+    Fn(Vec<Ty>),
+    /// `(F A …)` — application of a declared or catalogue type former
+    /// `F` (e.g. `(option 'a)`, `(coprod 'a unit)`). A bare type-former
+    /// name with no arguments is `App { head, args: [] }`.
+    App { head: Name, args: Vec<Ty> },
+}
+
+// ============================================================================
+// The term sublanguage
+// ============================================================================
+
+/// The **term sublanguage** — a simply-typed lambda calculus over the
+/// kernel's two logical primitives (`=`, `ε`) and the `defs/` catalogue.
+///
+/// This is the fragment in which `#def` bodies and the leaves of `(#by …)`
+/// proof scripts are written. It is deliberately *small and total*: it has
+/// variables, application, lambda, the kernel primitives, and the newtype
+/// coercions — nothing with its own operational semantics (reduction is
+/// the kernel's job; see `docs/surface-syntax.md` §1.1).
+///
+/// **Why it stands alone.** This sublanguage is the candidate we may
+/// eventually lift *into the TCB* as the native input format for writing
+/// `defs/` — replacing the hand-written `Term::app` / `Term::abs` plumbing
+/// in `covalence-core`. Keeping it as a closed, clearly-delimited grammar
+/// (rather than letting it bleed into the directive/proof layer) is what
+/// makes that move tractable: only these constructors would need a
+/// trusted elaboration into kernel `Term`s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Term {
+    /// A bare symbol: a bound variable, a theory-local constant, or a
+    /// dotted catalogue reference (`coprod.case`). Which one it is is the
+    /// elaborator's call (it depends on scope); the parser only records
+    /// the [`Name`].
+    Var(Name),
+    /// `(f x y …)` — curried application, `((f x) y) …`. `args` is always
+    /// non-empty (a lone `(f)` parses as `Var(f)`).
+    App { head: Box<Term>, args: Vec<Term> },
+    /// `(#lam x BODY)` or `(#lam (x A) BODY)` — lambda abstraction binding
+    /// `x` (optionally type-ascribed). The one non-trivial binder of the
+    /// sublanguage, and the reason it can express the `defs/` bodies at
+    /// all.
+    Lam {
+        /// The bound variable name.
+        param: SmolStr,
+        /// Its type, if ascribed (`(#lam (x A) …)`).
+        ty: Option<Ty>,
+        /// The body, with `param` in scope.
+        body: Box<Term>,
+    },
+    /// `(#eq a b)` — the kernel's primitive equality `=`.
+    Eq(Box<Term>, Box<Term>),
+    /// `(#sel (x A) P)` — Hilbert choice `ε`: "some `x : A` satisfying
+    /// `P`". The kernel's other primitive (`TermKind::Select`).
+    Select {
+        /// The chosen variable's name.
+        param: SmolStr,
+        /// Its type, if ascribed.
+        ty: Option<Ty>,
+        /// The predicate, with `param` in scope.
+        pred: Box<Term>,
+    },
+    /// `(#abs SPEC ARGS BODY)` — the carrier→wrapper coercion of a
+    /// `TypeSpec` (kernel `Term::spec_abs`). `SPEC` names the spec,
+    /// `ARGS` its type arguments.
+    Abs {
+        /// The `TypeSpec` being wrapped into.
+        spec: Name,
+        /// The spec's type arguments.
+        args: Vec<Ty>,
+        /// The carrier term.
+        body: Box<Term>,
+    },
+    /// `(#rep SPEC ARGS BODY)` — the wrapper→carrier coercion (kernel
+    /// `Term::spec_rep`). The inverse of [`Term::Abs`].
+    Rep {
+        /// The `TypeSpec` being unwrapped.
+        spec: Name,
+        /// The spec's type arguments.
+        args: Vec<Ty>,
+        /// The wrapper term.
+        body: Box<Term>,
+    },
+    /// An integer literal (kernel `TermKind::Int`). Written as a bare
+    /// numeral atom.
+    Int(Int),
+    /// `(#blob …)` — a byte-string literal (kernel `TermKind::Blob`).
+    Blob(Bytes),
+}
+
+// ============================================================================
+// Directives
+// ============================================================================
+
+/// A top-level **directive** — the unit a surface file is a sequence of.
+/// Each is a pure S-expression headed by a `#`-keyword.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Directive {
+    /// `(#theory NAME BODY…)` — open a named theory scope.
+    Theory {
+        /// The theory's name.
+        name: SmolStr,
+        /// The directives nested inside it.
+        body: Vec<Directive>,
+    },
+    /// `(#tydecl ITEM…)` — declare type formers and their kinds.
+    TyDecl(Vec<TyDeclItem>),
+    /// `(#decl SIG…)` — declare constants with their signatures.
+    Decl(Vec<Sig>),
+    /// `(#clause RULE…)` — an equational / Horn constraint: a
+    /// **disjunction** of [`Rule`]s, at least one of which must hold (see
+    /// `docs/surface-syntax.md` §4.1 for the positional binding
+    /// convention).
+    Clause(Vec<Rule>),
+    /// `(#def …)` — a tight definition with a body.
+    Def(Def),
+    /// `(#thm …)` — a named theorem and its proof.
+    Thm(ThmDecl),
+    /// `(#import …)` — pull in another theory / fragment.
+    Import(Import),
+}
+
+/// One item of a `#tydecl`: a type former with its parameters and result
+/// kind, e.g. `(option 'a #ty)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TyDeclItem {
+    /// The type former's name.
+    pub name: SmolStr,
+    /// Its declared type parameters (`'a`, …).
+    pub params: Vec<SmolStr>,
+    /// The result kind (`#ty` in `(option 'a #ty)`).
+    pub result: Kind,
+}
+
+/// One signature in a `#decl`: `(#sig NAME TYPE)` — the pure form of the
+/// sugar `NAME : TYPE`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sig {
+    /// The constant's name.
+    pub name: SmolStr,
+    /// Its type.
+    pub ty: Ty,
+}
+
+/// A single rewrite rule `(#rw LHS RHS)` — the pure form of the sugar
+/// `lhs => rhs`, asserting `lhs = rhs`. Variable binding is *positional*:
+/// a variable on the LHS is universally bound; one appearing only on the
+/// RHS is existentially bound.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rule {
+    /// The left-hand pattern.
+    pub lhs: Term,
+    /// The right-hand pattern.
+    pub rhs: Term,
+}
+
+/// A tight definition `(#def NAME SORT BODY)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Def {
+    /// The defined symbol.
+    pub name: SmolStr,
+    /// Whether this defines a type or a term, with the relevant
+    /// signature.
+    pub sort: DefSort,
+    /// The definition body.
+    pub body: DefBody,
+}
+
+/// The sort tag of a [`Def`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefSort {
+    /// `(#ty 'a …)` — a type definition with the given type parameters.
+    Type {
+        /// The type parameters.
+        params: Vec<SmolStr>,
+    },
+    /// `(#term TYPE)` — a term definition of the given type.
+    Term(Ty),
+}
+
+/// The body of a [`Def`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefBody {
+    /// `(#newtype CARRIER)` — a newtype over the given carrier type.
+    Newtype(Ty),
+    /// A term-sublanguage body (for term definitions).
+    Term(Term),
+}
+
+/// A named theorem `(#thm NAME STATEMENT (#by …))`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThmDecl {
+    /// The theorem's name.
+    pub name: SmolStr,
+    /// What it states.
+    pub statement: Statement,
+    /// Its proof script.
+    pub proof: Proof,
+}
+
+/// What a [`ThmDecl`] asserts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Statement {
+    /// `(#spec NAME)` — discharge a named spec obligation from a
+    /// `#clause`.
+    Spec(Name),
+    /// `(#concl TERM)` with optional `(#hyps TERM…)` — an explicit
+    /// sequent.
+    Sequent {
+        /// The hypotheses (empty if no `#hyps`).
+        hyps: Vec<Term>,
+        /// The conclusion.
+        concl: Term,
+    },
+}
+
+/// A proof script `(#by STEP…)`.
+///
+/// The tactic vocabulary (LCF-style combinators naming the kernel rules —
+/// see `docs/surface-syntax.md` §5) is a **later layer**; for now the
+/// sketch keeps the raw step S-expressions unparsed so the directive
+/// grammar can stabilize first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Proof {
+    /// The raw `#by` steps, pending a tactic grammar.
+    pub steps: Vec<covalence_sexp::SExpr>,
+}
+
+/// An `(#import …)` dependency edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Import {
+    /// What is imported.
+    pub target: ImportTarget,
+}
+
+/// The resolution target of an [`Import`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportTarget {
+    /// By name, resolved within the file (the only mode today).
+    Name(SmolStr),
+    /// By content hash — a `covalence-store` content-address. The
+    /// endgame (`docs/surface-syntax.md` §7); not yet resolvable.
+    Hash(SmolStr),
+}

--- a/crates/covalence-hol/src/surface/ast.rs
+++ b/crates/covalence-hol/src/surface/ast.rs
@@ -334,16 +334,10 @@ pub struct Proof {
 /// An `(#import …)` dependency edge.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Import {
-    /// What is imported.
-    pub target: ImportTarget,
-}
-
-/// The resolution target of an [`Import`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ImportTarget {
-    /// By name, resolved within the file (the only mode today).
-    Name(SmolStr),
-    /// By content hash — a `covalence-store` content-address. The
-    /// endgame (`docs/surface-syntax.md` §7); not yet resolvable.
-    Hash(SmolStr),
+    /// The imported theory / fragment name, resolved within the file.
+    ///
+    /// By-*hash* content addressing (a `covalence-store` content-address;
+    /// the endgame of `docs/surface-syntax.md` §7) is **not supported
+    /// yet** — only names for now.
+    pub name: SmolStr,
 }

--- a/crates/covalence-hol/src/surface/mod.rs
+++ b/crates/covalence-hol/src/surface/mod.rs
@@ -1,0 +1,259 @@
+//! Surface syntax — a "generalized Haskell" authoring layer (**DESIGN
+//! SKETCH; nothing here is wired into the kernel yet**).
+//!
+//! This module begins sketching the high-level language described in
+//! [`docs/surface-syntax.md`]: an S-expression syntax for writing
+//! theories, definitions, and proofs that *elaborates* down to the
+//! kernel objects of `covalence-core`. The canonical low-level
+//! S-expressions in [`crate::sexp`] are the *elaboration target*; this is
+//! the layer a human writes.
+//!
+//! ## Everything is a pure S-expression
+//!
+//! There is **no infix syntax**. The arrows, colons, and rewrite arrows
+//! in the design doc (`'a -> 'b`, `none : option 'a`, `lhs => rhs`) are
+//! prose *sugar* only. The real language is pure S-expressions in which
+//! every reserved word is a `#`-headed **builtin**:
+//!
+//! | sugar (doc prose) | pure form |
+//! |---|---|
+//! | `'a -> 'b` | `(#fn 'a 'b)` |
+//! | `none : option 'a` | `(#sig none (option 'a))` |
+//! | `lhs => rhs` | `(#rw lhs rhs)` |
+//! | `(= a b)` | `(#eq a b)` |
+//! | `λa. body` / `(lam a body)` | `(#lam a body)` |
+//! | `(by …)` | `(#by …)` |
+//!
+//! Tokens fall into three lexical classes, by spelling alone (see
+//! [`ast::Name::class`]):
+//!
+//! - `#…` — a **builtin** keyword ([`Builtin`]).
+//! - `'…` — a **type variable**.
+//! - everything else — an ordinary **name**: a dotted *catalogue*
+//!   reference (`coprod.case`) or a *local* name (`option`, `e`, `f`).
+//!
+//! ## The term sublanguage
+//!
+//! A distinguished, self-contained fragment — [`ast::Term`] — is the
+//! *term sublanguage*: a simply-typed lambda calculus (variables,
+//! application, `#lam`, the kernel primitives `#eq`/`#sel`, the newtype
+//! coercions `#abs`/`#rep`) in which `#def` bodies are written. It
+//! deliberately has **no operational semantics of its own** — reduction
+//! is the kernel's job. It is kept as a closed grammar because it is the
+//! candidate we may eventually lift *into the TCB* as the native input
+//! format for writing `defs/`, retiring the hand-written `Term::app` /
+//! `Term::abs` plumbing in `covalence-core`.
+//!
+//! ## Status
+//!
+//! The AST ([`ast`]) is sketched; [`parse`] is a stub (see
+//! `SKELETONS.md`). The elaborator (surface → low-level S-expr → kernel
+//! object) is future work; see `docs/surface-syntax.md` §8.
+//!
+//! [`docs/surface-syntax.md`]: ../../../docs/surface-syntax.md
+
+pub mod ast;
+
+pub use ast::{
+    Def, DefBody, DefSort, Directive, Import, ImportTarget, Kind, Name, NameClass, Proof, Rule,
+    Sig, Statement, Term, ThmDecl, Ty, TyDeclItem,
+};
+
+/// The reserved `#`-headed keywords of the surface language.
+///
+/// This is the registry that makes [`NameClass::Builtin`] meaningful: a
+/// token spelled `#foo` that is not one of these is a *malformed*
+/// builtin, which the parser should reject rather than silently treat as
+/// a name. The set is **provisional** — it will grow as the directive,
+/// type, and term grammars are pinned down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Builtin {
+    // --- directive heads ---
+    /// `#theory` — open a named theory scope.
+    Theory,
+    /// `#tydecl` — declare type formers + kinds.
+    TyDecl,
+    /// `#decl` — declare constants + signatures.
+    Decl,
+    /// `#clause` — an equational / Horn constraint (a disjunction of
+    /// `#rw` rules).
+    Clause,
+    /// `#def` — a tight definition with a body.
+    Def,
+    /// `#thm` — a named theorem + proof.
+    Thm,
+    /// `#import` — a dependency edge.
+    Import,
+
+    // --- kinds & types ---
+    /// `#ty` — the kind of proper types.
+    Ty,
+    /// `#prop` — the type of propositions.
+    Prop,
+    /// `#bytes` — the type of `#blob` literals.
+    Bytes,
+    /// `#fn` — the function-type / kind arrow.
+    Fn,
+
+    // --- statement / directive forms ---
+    /// `#sig` — a `name : type` signature.
+    Sig,
+    /// `#rw` — a `lhs => rhs` rewrite rule.
+    Rw,
+    /// `#term` — the term sort tag of a `#def`, or a term-typed sequent.
+    Term,
+    /// `#newtype` — a newtype `#def` body.
+    Newtype,
+    /// `#spec` — a named spec obligation as a theorem statement.
+    Spec,
+    /// `#concl` — the conclusion of an explicit sequent.
+    Concl,
+    /// `#hyps` — the hypotheses of an explicit sequent.
+    Hyps,
+    /// `#by` — a proof script.
+    By,
+
+    // --- term sublanguage ---
+    /// `#lam` — lambda abstraction.
+    Lam,
+    /// `#eq` — primitive equality `=`.
+    Eq,
+    /// `#sel` — Hilbert choice `ε`.
+    Sel,
+    /// `#abs` — `TypeSpec` carrier→wrapper coercion.
+    Abs,
+    /// `#rep` — `TypeSpec` wrapper→carrier coercion.
+    Rep,
+    /// `#blob` — a byte-string literal.
+    Blob,
+}
+
+impl Builtin {
+    /// The spelling of this builtin, including the leading `#`.
+    pub fn as_str(self) -> &'static str {
+        use Builtin::*;
+        match self {
+            Theory => "#theory",
+            TyDecl => "#tydecl",
+            Decl => "#decl",
+            Clause => "#clause",
+            Def => "#def",
+            Thm => "#thm",
+            Import => "#import",
+            Ty => "#ty",
+            Prop => "#prop",
+            Bytes => "#bytes",
+            Fn => "#fn",
+            Sig => "#sig",
+            Rw => "#rw",
+            Term => "#term",
+            Newtype => "#newtype",
+            Spec => "#spec",
+            Concl => "#concl",
+            Hyps => "#hyps",
+            By => "#by",
+            Lam => "#lam",
+            Eq => "#eq",
+            Sel => "#sel",
+            Abs => "#abs",
+            Rep => "#rep",
+            Blob => "#blob",
+        }
+    }
+
+    /// Parse a builtin from its spelling (with the leading `#`). Returns
+    /// `None` for any other token — including a malformed `#foo`.
+    pub fn from_keyword(s: &str) -> Option<Builtin> {
+        use Builtin::*;
+        Some(match s {
+            "#theory" => Theory,
+            "#tydecl" => TyDecl,
+            "#decl" => Decl,
+            "#clause" => Clause,
+            "#def" => Def,
+            "#thm" => Thm,
+            "#import" => Import,
+            "#ty" => Ty,
+            "#prop" => Prop,
+            "#bytes" => Bytes,
+            "#fn" => Fn,
+            "#sig" => Sig,
+            "#rw" => Rw,
+            "#term" => Term,
+            "#newtype" => Newtype,
+            "#spec" => Spec,
+            "#concl" => Concl,
+            "#hyps" => Hyps,
+            "#by" => By,
+            "#lam" => Lam,
+            "#eq" => Eq,
+            "#sel" => Sel,
+            "#abs" => Abs,
+            "#rep" => Rep,
+            "#blob" => Blob,
+            _ => return None,
+        })
+    }
+}
+
+/// Errors from parsing / lowering the surface syntax.
+#[derive(Debug, thiserror::Error)]
+pub enum SurfaceError {
+    /// A part of the surface front-end that is sketched but not yet
+    /// implemented (see `SKELETONS.md`).
+    #[error("surface syntax: not yet implemented: {0}")]
+    NotImplemented(&'static str),
+    /// A structural error in the S-expression shape.
+    #[error("surface syntax: {0}")]
+    Malformed(String),
+}
+
+/// Parse a sequence of surface [`Directive`]s from already-parsed
+/// S-expressions (use [`covalence_sexp::parse`] to get the input).
+///
+/// **Skeleton:** the AST in [`ast`] is fully sketched but the lowering
+/// from [`covalence_sexp::SExpr`] is not written yet. Tracked in
+/// `SKELETONS.md`.
+pub fn parse(_exprs: &[covalence_sexp::SExpr]) -> Result<Vec<Directive>, SurfaceError> {
+    Err(SurfaceError::NotImplemented(
+        "surface::parse: S-expression lowering to the directive AST",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtins_round_trip() {
+        for b in [
+            Builtin::Theory,
+            Builtin::Fn,
+            Builtin::Lam,
+            Builtin::Eq,
+            Builtin::Rw,
+            Builtin::Blob,
+        ] {
+            assert_eq!(Builtin::from_keyword(b.as_str()), Some(b));
+            assert!(b.as_str().starts_with('#'));
+        }
+        assert_eq!(Builtin::from_keyword("#nope"), None);
+        assert_eq!(Builtin::from_keyword("option"), None);
+    }
+
+    #[test]
+    fn name_classes() {
+        assert_eq!(Name("#fn".into()).class(), NameClass::Builtin);
+        assert_eq!(Name("'a".into()).class(), NameClass::TyVar);
+        assert_eq!(Name("coprod.case".into()).class(), NameClass::Catalogue);
+        assert_eq!(Name("option".into()).class(), NameClass::Local);
+    }
+
+    #[test]
+    fn parse_is_stubbed() {
+        assert!(matches!(
+            parse(&[]),
+            Err(SurfaceError::NotImplemented(_))
+        ));
+    }
+}

--- a/crates/covalence-hol/src/surface/mod.rs
+++ b/crates/covalence-hol/src/surface/mod.rs
@@ -57,8 +57,8 @@ pub mod ast;
 mod parse;
 
 pub use ast::{
-    Def, DefBody, DefSort, Directive, Import, ImportTarget, Kind, Name, NameClass, Proof, Rule,
-    Sig, Statement, Term, ThmDecl, Ty, TyDeclItem,
+    Def, DefBody, DefSort, Directive, Import, Kind, Name, NameClass, Proof, Rule, Sig, Statement,
+    Term, ThmDecl, Ty, TyDeclItem,
 };
 pub use parse::{parse, parse_str};
 

--- a/crates/covalence-hol/src/surface/mod.rs
+++ b/crates/covalence-hol/src/surface/mod.rs
@@ -46,18 +46,21 @@
 //!
 //! ## Status
 //!
-//! The AST ([`ast`]) is sketched; [`parse`] is a stub (see
-//! `SKELETONS.md`). The elaborator (surface → low-level S-expr → kernel
-//! object) is future work; see `docs/surface-syntax.md` §8.
+//! The AST ([`ast`]) is sketched and [`parse`] / [`parse_str`] lower pure
+//! S-expressions into it. The *elaborator* (surface → low-level S-expr →
+//! kernel object), the `#by` tactic grammar, and `#import` content
+//! addressing are future work; see `docs/surface-syntax.md` §8.
 //!
 //! [`docs/surface-syntax.md`]: ../../../docs/surface-syntax.md
 
 pub mod ast;
+mod parse;
 
 pub use ast::{
     Def, DefBody, DefSort, Directive, Import, ImportTarget, Kind, Name, NameClass, Proof, Rule,
     Sig, Statement, Term, ThmDecl, Ty, TyDeclItem,
 };
+pub use parse::{parse, parse_str};
 
 /// The reserved `#`-headed keywords of the surface language.
 ///
@@ -199,25 +202,9 @@ impl Builtin {
 /// Errors from parsing / lowering the surface syntax.
 #[derive(Debug, thiserror::Error)]
 pub enum SurfaceError {
-    /// A part of the surface front-end that is sketched but not yet
-    /// implemented (see `SKELETONS.md`).
-    #[error("surface syntax: not yet implemented: {0}")]
-    NotImplemented(&'static str),
     /// A structural error in the S-expression shape.
     #[error("surface syntax: {0}")]
     Malformed(String),
-}
-
-/// Parse a sequence of surface [`Directive`]s from already-parsed
-/// S-expressions (use [`covalence_sexp::parse`] to get the input).
-///
-/// **Skeleton:** the AST in [`ast`] is fully sketched but the lowering
-/// from [`covalence_sexp::SExpr`] is not written yet. Tracked in
-/// `SKELETONS.md`.
-pub fn parse(_exprs: &[covalence_sexp::SExpr]) -> Result<Vec<Directive>, SurfaceError> {
-    Err(SurfaceError::NotImplemented(
-        "surface::parse: S-expression lowering to the directive AST",
-    ))
 }
 
 #[cfg(test)]
@@ -247,13 +234,5 @@ mod tests {
         assert_eq!(Name("'a".into()).class(), NameClass::TyVar);
         assert_eq!(Name("coprod.case".into()).class(), NameClass::Catalogue);
         assert_eq!(Name("option".into()).class(), NameClass::Local);
-    }
-
-    #[test]
-    fn parse_is_stubbed() {
-        assert!(matches!(
-            parse(&[]),
-            Err(SurfaceError::NotImplemented(_))
-        ));
     }
 }

--- a/crates/covalence-hol/src/surface/parse.rs
+++ b/crates/covalence-hol/src/surface/parse.rs
@@ -450,19 +450,15 @@ fn proof(e: &SExpr) -> Result<Proof> {
     })
 }
 
-/// `(#import TARGET)` — a name (symbol) or a content hash (string).
+/// `(#import NAME)` — by name only; by-hash content addressing is future
+/// work (`docs/surface-syntax.md` §7).
 fn import(args: &[SExpr]) -> Result<Import> {
-    let [target] = exact(args, 1, "`(#import TARGET)`")? else {
+    let [target] = exact(args, 1, "`(#import NAME)`")? else {
         unreachable!()
     };
-    let target = if let Some(s) = target.as_symbol() {
-        ImportTarget::Name(SmolStr::new(s))
-    } else if let Some((_fmt, bytes)) = target.as_str() {
-        ImportTarget::Hash(SmolStr::new(String::from_utf8_lossy(bytes)))
-    } else {
-        return Err(malformed("`#import` target must be a name or a hash string"));
-    };
-    Ok(Import { target })
+    Ok(Import {
+        name: SmolStr::new(symbol(target, "an import name")?),
+    })
 }
 
 #[cfg(test)]
@@ -563,6 +559,17 @@ mod tests {
         assert!(matches!(*head, Term::Var(_)));
         assert!(matches!(args[0], Term::Int(_)));
         assert!(matches!(args[1], Term::Var(_)));
+    }
+
+    #[test]
+    fn import_by_name() {
+        let dirs = parse_str("(#import option)").unwrap();
+        let [Directive::Import(i)] = dirs.as_slice() else {
+            panic!("expected an #import");
+        };
+        assert_eq!(i.name, "option");
+        // Hash strings are not a thing yet.
+        assert!(parse_str(r#"(#import "deadbeef")"#).is_err());
     }
 
     #[test]

--- a/crates/covalence-hol/src/surface/parse.rs
+++ b/crates/covalence-hol/src/surface/parse.rs
@@ -1,0 +1,574 @@
+//! Lowering from S-expressions to the surface [`ast`](crate::surface::ast).
+//!
+//! Pure forms only: there is **no sugar**. The parser accepts exactly the
+//! `#`-headed builtin grammar — `(#fn …)`, `(#sig …)`, `(#rw …)`, etc. The
+//! informal arrows / colons used in `docs/surface-syntax.md` prose are not
+//! a language feature and are not accepted here.
+
+use covalence_sexp::{SExpr, parse as parse_sexp};
+use covalence_types::Int;
+use smol_str::SmolStr;
+
+use super::ast::*;
+use super::{Builtin, SurfaceError};
+
+type Result<T> = std::result::Result<T, SurfaceError>;
+
+fn malformed(msg: impl Into<String>) -> SurfaceError {
+    SurfaceError::Malformed(msg.into())
+}
+
+// ============================================================================
+// Entry points
+// ============================================================================
+
+/// Parse a sequence of surface [`Directive`]s from already-parsed
+/// S-expressions. Each top-level S-expression is one directive.
+pub fn parse(exprs: &[SExpr]) -> Result<Vec<Directive>> {
+    exprs.iter().map(directive).collect()
+}
+
+/// Parse surface [`Directive`]s directly from source text, lexing through
+/// [`covalence_sexp::parse`] (the Covalence dialect) first.
+pub fn parse_str(src: &str) -> Result<Vec<Directive>> {
+    let exprs = parse_sexp(src).map_err(|e| malformed(format!("s-expression syntax: {e}")))?;
+    parse(&exprs)
+}
+
+// ============================================================================
+// Small helpers over SExpr
+// ============================================================================
+
+/// The children of a non-empty list, or an error naming `ctx`.
+fn list<'a>(e: &'a SExpr, ctx: &str) -> Result<&'a [SExpr]> {
+    match e.as_list() {
+        Some(items) if !items.is_empty() => Ok(items),
+        Some(_) => Err(malformed(format!("empty list where {ctx} expected"))),
+        None => Err(malformed(format!("expected {ctx}, found an atom"))),
+    }
+}
+
+/// The symbol text of an atom, or an error naming `ctx`.
+fn symbol<'a>(e: &'a SExpr, ctx: &str) -> Result<&'a str> {
+    e.as_symbol()
+        .ok_or_else(|| malformed(format!("expected {ctx} (a symbol)")))
+}
+
+/// The head symbol of a list, if it is a symbol.
+fn head_symbol(items: &[SExpr]) -> Option<&str> {
+    items.first().and_then(|e| e.as_symbol())
+}
+
+/// Require exactly `n` argument children (the slice *after* the head).
+fn exact<'a>(args: &'a [SExpr], n: usize, form: &str) -> Result<&'a [SExpr]> {
+    if args.len() == n {
+        Ok(args)
+    } else {
+        Err(malformed(format!(
+            "{form} takes {n} argument(s), got {}",
+            args.len()
+        )))
+    }
+}
+
+// ============================================================================
+// Kinds & types
+// ============================================================================
+
+fn kind(e: &SExpr) -> Result<Kind> {
+    if let Some(s) = e.as_symbol() {
+        return match Builtin::from_keyword(s) {
+            Some(Builtin::Ty) => Ok(Kind::Ty),
+            _ => Err(malformed(format!("`{s}` is not a kind (expected `#ty`)"))),
+        };
+    }
+    let items = list(e, "a kind")?;
+    match head_symbol(items).and_then(Builtin::from_keyword) {
+        Some(Builtin::Fn) => {
+            let ks = items[1..].iter().map(kind).collect::<Result<Vec<_>>>()?;
+            if ks.len() < 2 {
+                return Err(malformed("`(#fn …)` kind needs at least two parts"));
+            }
+            Ok(Kind::Fn(ks))
+        }
+        _ => Err(malformed("expected a kind: `#ty` or `(#fn …)`")),
+    }
+}
+
+fn ty(e: &SExpr) -> Result<Ty> {
+    if let Some(s) = e.as_symbol() {
+        if let Some(b) = Builtin::from_keyword(s) {
+            return match b {
+                Builtin::Prop => Ok(Ty::Prop),
+                Builtin::Bytes => Ok(Ty::Bytes),
+                _ => Err(malformed(format!("`{s}` is not a type"))),
+            };
+        }
+        if s.starts_with('\'') {
+            return Ok(Ty::Var(SmolStr::new(s)));
+        }
+        // A nullary type former, e.g. `unit`.
+        return Ok(Ty::App {
+            head: Name(SmolStr::new(s)),
+            args: Vec::new(),
+        });
+    }
+    let items = list(e, "a type")?;
+    match head_symbol(items) {
+        Some(h) if Builtin::from_keyword(h) == Some(Builtin::Fn) => {
+            let parts = items[1..].iter().map(ty).collect::<Result<Vec<_>>>()?;
+            if parts.len() < 2 {
+                return Err(malformed("`(#fn …)` type needs at least two parts"));
+            }
+            Ok(Ty::Fn(parts))
+        }
+        Some(h) if Builtin::from_keyword(h).is_some() => {
+            Err(malformed(format!("`{h}` is not a type-forming builtin")))
+        }
+        Some(h) => {
+            // `(F A …)` — application of a named type former.
+            let args = items[1..].iter().map(ty).collect::<Result<Vec<_>>>()?;
+            Ok(Ty::App {
+                head: Name(SmolStr::new(h)),
+                args,
+            })
+        }
+        None => Err(malformed("a type former must be a name")),
+    }
+}
+
+/// Parse the `(ty …)` argument list of `#abs` / `#rep`.
+fn ty_args(e: &SExpr) -> Result<Vec<Ty>> {
+    match e.as_list() {
+        Some(items) => items.iter().map(ty).collect(),
+        None => Err(malformed("expected a `(…)` list of type arguments")),
+    }
+}
+
+// ============================================================================
+// The term sublanguage
+// ============================================================================
+
+/// A binder `x` or `(x A)` — used by `#lam` and `#sel`.
+fn binder(e: &SExpr) -> Result<(SmolStr, Option<Ty>)> {
+    if let Some(s) = e.as_symbol() {
+        return Ok((SmolStr::new(s), None));
+    }
+    let items = list(e, "a binder")?;
+    let [name, t] = exact(items, 2, "a `(x A)` binder")? else {
+        unreachable!()
+    };
+    Ok((SmolStr::new(symbol(name, "a binder name")?), Some(ty(t)?)))
+}
+
+fn term(e: &SExpr) -> Result<Term> {
+    if let Some(s) = e.as_symbol() {
+        if let Ok(n) = s.parse::<Int>() {
+            return Ok(Term::Int(n));
+        }
+        if Builtin::from_keyword(s).is_some() {
+            return Err(malformed(format!("`{s}` is a builtin, not a term")));
+        }
+        return Ok(Term::Var(Name(SmolStr::new(s))));
+    }
+    let items = list(e, "a term")?;
+    if let Some(h) = head_symbol(items)
+        && let Some(b) = Builtin::from_keyword(h)
+    {
+        return term_builtin(b, &items[1..]);
+    }
+    if items.len() == 1 {
+        // `(x)` is just `x`.
+        return term(&items[0]);
+    }
+    // Curried application `(f x y …)`.
+    let head = Box::new(term(&items[0])?);
+    let args = items[1..].iter().map(term).collect::<Result<Vec<_>>>()?;
+    Ok(Term::App { head, args })
+}
+
+fn term_builtin(b: Builtin, args: &[SExpr]) -> Result<Term> {
+    match b {
+        Builtin::Lam => {
+            let [bind, body] = exact(args, 2, "`(#lam BINDER BODY)`")? else {
+                unreachable!()
+            };
+            let (param, ty) = binder(bind)?;
+            Ok(Term::Lam {
+                param,
+                ty,
+                body: Box::new(term(body)?),
+            })
+        }
+        Builtin::Eq => {
+            let [a, c] = exact(args, 2, "`(#eq A B)`")? else {
+                unreachable!()
+            };
+            Ok(Term::Eq(Box::new(term(a)?), Box::new(term(c)?)))
+        }
+        Builtin::Sel => {
+            let [bind, pred] = exact(args, 2, "`(#sel BINDER PRED)`")? else {
+                unreachable!()
+            };
+            let (param, ty) = binder(bind)?;
+            Ok(Term::Select {
+                param,
+                ty,
+                pred: Box::new(term(pred)?),
+            })
+        }
+        Builtin::Abs | Builtin::Rep => {
+            let [spec, targs, body] = exact(args, 3, "`(#abs SPEC (TY…) BODY)`")? else {
+                unreachable!()
+            };
+            let spec = Name(SmolStr::new(symbol(spec, "a spec name")?));
+            let targs = ty_args(targs)?;
+            let body = Box::new(term(body)?);
+            Ok(if b == Builtin::Abs {
+                Term::Abs {
+                    spec,
+                    args: targs,
+                    body,
+                }
+            } else {
+                Term::Rep {
+                    spec,
+                    args: targs,
+                    body,
+                }
+            })
+        }
+        Builtin::Blob => {
+            let [lit] = exact(args, 1, "`(#blob BYTES)`")? else {
+                unreachable!()
+            };
+            let (_fmt, bytes) = lit
+                .as_str()
+                .ok_or_else(|| malformed("`#blob` payload must be a string literal"))?;
+            Ok(Term::Blob(bytes.to_vec().into()))
+        }
+        other => Err(malformed(format!(
+            "`{}` is not a term form",
+            other.as_str()
+        ))),
+    }
+}
+
+// ============================================================================
+// Directives
+// ============================================================================
+
+fn directive(e: &SExpr) -> Result<Directive> {
+    let items = list(e, "a directive")?;
+    let head = head_symbol(items)
+        .ok_or_else(|| malformed("a directive must start with a `#`-keyword"))?;
+    let b = Builtin::from_keyword(head)
+        .ok_or_else(|| malformed(format!("`{head}` is not a directive keyword")))?;
+    let args = &items[1..];
+    match b {
+        Builtin::Theory => {
+            let (name, rest) = args
+                .split_first()
+                .ok_or_else(|| malformed("`#theory` needs a name"))?;
+            let name = SmolStr::new(symbol(name, "a theory name")?);
+            let body = rest.iter().map(directive).collect::<Result<Vec<_>>>()?;
+            Ok(Directive::Theory { name, body })
+        }
+        Builtin::TyDecl => Ok(Directive::TyDecl(
+            args.iter().map(tydecl_item).collect::<Result<Vec<_>>>()?,
+        )),
+        Builtin::Decl => Ok(Directive::Decl(
+            args.iter().map(sig).collect::<Result<Vec<_>>>()?,
+        )),
+        Builtin::Clause => Ok(Directive::Clause(
+            args.iter().map(rule).collect::<Result<Vec<_>>>()?,
+        )),
+        Builtin::Def => def(args).map(Directive::Def),
+        Builtin::Thm => thm(args).map(Directive::Thm),
+        Builtin::Import => import(args).map(Directive::Import),
+        other => Err(malformed(format!(
+            "`{}` is not a top-level directive",
+            other.as_str()
+        ))),
+    }
+}
+
+/// `(NAME PARAM… RESULT-KIND)`, e.g. `(option 'a #ty)`.
+fn tydecl_item(e: &SExpr) -> Result<TyDeclItem> {
+    let items = list(e, "a `#tydecl` item")?;
+    if items.len() < 2 {
+        return Err(malformed(
+            "a `#tydecl` item is `(NAME PARAM… RESULT-KIND)`",
+        ));
+    }
+    let name = SmolStr::new(symbol(&items[0], "a type-former name")?);
+    let (result, params_src) = items[1..]
+        .split_last()
+        .expect("len >= 2 checked above");
+    let params = params_src
+        .iter()
+        .map(|p| {
+            let s = symbol(p, "a type parameter")?;
+            if !s.starts_with('\'') {
+                return Err(malformed(format!("type parameter `{s}` must start with `'`")));
+            }
+            Ok(SmolStr::new(s))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(TyDeclItem {
+        name,
+        params,
+        result: kind(result)?,
+    })
+}
+
+/// `(#sig NAME TYPE)`.
+fn sig(e: &SExpr) -> Result<Sig> {
+    let items = list(e, "a `#sig`")?;
+    if head_symbol(items).and_then(Builtin::from_keyword) != Some(Builtin::Sig) {
+        return Err(malformed("a `#decl` entry must be `(#sig NAME TYPE)`"));
+    }
+    let [name, t] = exact(&items[1..], 2, "`(#sig NAME TYPE)`")? else {
+        unreachable!()
+    };
+    Ok(Sig {
+        name: SmolStr::new(symbol(name, "a constant name")?),
+        ty: ty(t)?,
+    })
+}
+
+/// `(#rw LHS RHS)`.
+fn rule(e: &SExpr) -> Result<Rule> {
+    let items = list(e, "a `#rw` rule")?;
+    if head_symbol(items).and_then(Builtin::from_keyword) != Some(Builtin::Rw) {
+        return Err(malformed("a `#clause` entry must be `(#rw LHS RHS)`"));
+    }
+    let [lhs, rhs] = exact(&items[1..], 2, "`(#rw LHS RHS)`")? else {
+        unreachable!()
+    };
+    Ok(Rule {
+        lhs: term(lhs)?,
+        rhs: term(rhs)?,
+    })
+}
+
+/// `(#def NAME SORT BODY)`.
+fn def(args: &[SExpr]) -> Result<Def> {
+    let [name, sort_e, body_e] = exact(args, 3, "`(#def NAME SORT BODY)`")? else {
+        unreachable!()
+    };
+    let name = SmolStr::new(symbol(name, "a definition name")?);
+    let sort_items = list(sort_e, "a `#def` sort")?;
+    let sort = match head_symbol(sort_items).and_then(Builtin::from_keyword) {
+        Some(Builtin::Ty) => {
+            let params = sort_items[1..]
+                .iter()
+                .map(|p| Ok(SmolStr::new(symbol(p, "a type parameter")?)))
+                .collect::<Result<Vec<_>>>()?;
+            DefSort::Type { params }
+        }
+        Some(Builtin::Term) => {
+            let [t] = exact(&sort_items[1..], 1, "`(#term TYPE)`")? else {
+                unreachable!()
+            };
+            DefSort::Term(ty(t)?)
+        }
+        _ => return Err(malformed("a `#def` sort is `(#ty …)` or `(#term TYPE)`")),
+    };
+    let body = match body_e.as_list().and_then(head_symbol).and_then(Builtin::from_keyword) {
+        Some(Builtin::Newtype) => {
+            let items = body_e.as_list().expect("matched a list above");
+            let [carrier] = exact(&items[1..], 1, "`(#newtype CARRIER)`")? else {
+                unreachable!()
+            };
+            DefBody::Newtype(ty(carrier)?)
+        }
+        _ => DefBody::Term(term(body_e)?),
+    };
+    Ok(Def { name, sort, body })
+}
+
+/// `(#thm NAME STATEMENT (#by …))`.
+fn thm(args: &[SExpr]) -> Result<ThmDecl> {
+    let (name, rest) = args
+        .split_first()
+        .ok_or_else(|| malformed("`#thm` needs a name"))?;
+    let name = SmolStr::new(symbol(name, "a theorem name")?);
+    let (proof_e, stmt_src) = rest
+        .split_last()
+        .ok_or_else(|| malformed("`#thm` needs a statement and a `(#by …)` proof"))?;
+    let proof = proof(proof_e)?;
+    let statement = statement(stmt_src)?;
+    Ok(ThmDecl {
+        name,
+        statement,
+        proof,
+    })
+}
+
+/// The statement children of a `#thm`: either a single `(#spec NAME)`, or
+/// an optional `(#hyps …)` followed by a `(#concl TERM)`.
+fn statement(src: &[SExpr]) -> Result<Statement> {
+    if let [single] = src
+        && let Some(items) = single.as_list()
+        && head_symbol(items).and_then(Builtin::from_keyword) == Some(Builtin::Spec)
+    {
+        let [name] = exact(&items[1..], 1, "`(#spec NAME)`")? else {
+            unreachable!()
+        };
+        return Ok(Statement::Spec(Name(SmolStr::new(symbol(name, "a spec name")?))));
+    }
+    let mut hyps = Vec::new();
+    let mut concl = None;
+    for part in src {
+        let items = list(part, "a `#thm` statement clause")?;
+        match head_symbol(items).and_then(Builtin::from_keyword) {
+            Some(Builtin::Hyps) => {
+                hyps = items[1..].iter().map(term).collect::<Result<Vec<_>>>()?;
+            }
+            Some(Builtin::Concl) => {
+                let [c] = exact(&items[1..], 1, "`(#concl TERM)`")? else {
+                    unreachable!()
+                };
+                concl = Some(term(c)?);
+            }
+            _ => return Err(malformed("`#thm` statement expects `#concl` / `#hyps` / `#spec`")),
+        }
+    }
+    let concl = concl.ok_or_else(|| malformed("`#thm` statement needs a `(#concl TERM)`"))?;
+    Ok(Statement::Sequent { hyps, concl })
+}
+
+/// `(#by STEP…)` — steps kept raw pending a tactic grammar (see §5).
+fn proof(e: &SExpr) -> Result<Proof> {
+    let items = list(e, "a `(#by …)` proof")?;
+    if head_symbol(items).and_then(Builtin::from_keyword) != Some(Builtin::By) {
+        return Err(malformed("a `#thm` proof must be `(#by …)`"));
+    }
+    Ok(Proof {
+        steps: items[1..].to_vec(),
+    })
+}
+
+/// `(#import TARGET)` — a name (symbol) or a content hash (string).
+fn import(args: &[SExpr]) -> Result<Import> {
+    let [target] = exact(args, 1, "`(#import TARGET)`")? else {
+        unreachable!()
+    };
+    let target = if let Some(s) = target.as_symbol() {
+        ImportTarget::Name(SmolStr::new(s))
+    } else if let Some((_fmt, bytes)) = target.as_str() {
+        ImportTarget::Hash(SmolStr::new(String::from_utf8_lossy(bytes)))
+    } else {
+        return Err(malformed("`#import` target must be a name or a hash string"));
+    };
+    Ok(Import { target })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn option_spec_round_trips() {
+        let src = r#"
+            (#theory option
+              (#tydecl
+                (option 'a #ty))
+              (#decl
+                (#sig none (option 'a))
+                (#sig some (#fn 'a (option 'a)))
+                (#sig case (#fn (option 'a) 'b (#fn 'a 'b) 'b)))
+              (#clause
+                (#rw e none)
+                (#rw e (some a)))
+              (#clause
+                (#rw (case none b f) b))
+              (#clause
+                (#rw (case (some a) b f) (f a))))
+        "#;
+        let dirs = parse_str(src).expect("parse");
+        let [Directive::Theory { name, body }] = dirs.as_slice() else {
+            panic!("expected a single #theory, got {dirs:?}");
+        };
+        assert_eq!(name, "option");
+        // tydecl, decl, clause, clause, clause
+        assert_eq!(body.len(), 5);
+        assert!(matches!(body[0], Directive::TyDecl(_)));
+        let Directive::Decl(sigs) = &body[1] else {
+            panic!("expected #decl");
+        };
+        assert_eq!(sigs.len(), 3);
+        assert_eq!(sigs[0].name, "none");
+        // some : 'a -> option 'a
+        assert!(matches!(sigs[1].ty, Ty::Fn(_)));
+    }
+
+    #[test]
+    fn def_with_lambda_and_coercion() {
+        // some := λa. abs (inl a)
+        let src = "(#def some (#term (#fn 'a (option 'a))) \
+                   (#lam a (#abs option ('a) (inl a))))";
+        let dirs = parse_str(src).expect("parse");
+        let [Directive::Def(d)] = dirs.as_slice() else {
+            panic!("expected a #def");
+        };
+        assert_eq!(d.name, "some");
+        assert!(matches!(d.sort, DefSort::Term(Ty::Fn(_))));
+        let DefBody::Term(Term::Lam { param, body, .. }) = &d.body else {
+            panic!("expected a lambda body");
+        };
+        assert_eq!(param, "a");
+        assert!(matches!(**body, Term::Abs { .. }));
+    }
+
+    #[test]
+    fn newtype_def() {
+        let dirs = parse_str("(#def option (#ty 'a) (#newtype (coprod 'a unit)))").unwrap();
+        let [Directive::Def(d)] = dirs.as_slice() else {
+            panic!();
+        };
+        assert!(matches!(d.sort, DefSort::Type { .. }));
+        assert!(matches!(d.body, DefBody::Newtype(Ty::App { .. })));
+    }
+
+    #[test]
+    fn thm_spec_and_sequent() {
+        let dirs = parse_str(
+            "(#thm option/exhaustive (#spec option.exhaustive) (#by step1 step2))",
+        )
+        .unwrap();
+        let [Directive::Thm(t)] = dirs.as_slice() else {
+            panic!();
+        };
+        assert!(matches!(t.statement, Statement::Spec(_)));
+        assert_eq!(t.proof.steps.len(), 2);
+
+        let dirs = parse_str("(#thm t (#concl (#eq a b)) (#by))").unwrap();
+        let [Directive::Thm(t)] = dirs.as_slice() else {
+            panic!();
+        };
+        assert!(matches!(
+            t.statement,
+            Statement::Sequent { ref hyps, .. } if hyps.is_empty()
+        ));
+    }
+
+    #[test]
+    fn int_literal_and_application() {
+        let Term::App { head, args } = term(&parse_sexp("(nat.add 1 x)").unwrap()[0]).unwrap()
+        else {
+            panic!("expected application");
+        };
+        assert!(matches!(*head, Term::Var(_)));
+        assert!(matches!(args[0], Term::Int(_)));
+        assert!(matches!(args[1], Term::Var(_)));
+    }
+
+    #[test]
+    fn rejects_unknown_builtin() {
+        assert!(parse_str("(#wat foo)").is_err());
+        // bare arrow is not a thing — no sugar.
+        assert!(ty(&parse_sexp("(-> 'a 'b)").unwrap()[0]).is_ok_and(|t| matches!(t, Ty::App { .. })));
+    }
+}

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -93,13 +93,17 @@ makes "the query planner can be an LLM" a safe thing to say out loud.
 
 ### 1.3 Everything is a pure S-expression
 
-There is **no infix syntax**. The arrows, colons, and rewrite arrows
-that appear in this document — `'a -> 'b`, `none : option 'a`, `lhs =>
-rhs` — are **prose sugar for readability only**. The actual language is
-*pure S-expressions*, in which every reserved word is a **`#`-headed
-builtin**:
+The language is **pure S-expressions with no sugar**. There is no infix
+syntax and no surface-level shorthand: every reserved word is a
+**`#`-headed builtin**, and the parser (`surface::parse` /
+`surface::parse_str`) accepts *only* these forms — nothing desugars.
 
-| sugar (used in prose below) | pure form |
+The arrows, colons, and rewrite arrows that still appear in this
+document — `'a -> 'b`, `none : option 'a`, `lhs => rhs` — are **informal
+notation in the prose of this doc only**; they are *not* part of the
+language and are *not* accepted by the parser. The real forms are:
+
+| informal notation in this doc | actual (and only) form |
 |---|---|
 | `'a -> 'b` | `(#fn 'a 'b)` |
 | `none : option 'a` | `(#sig none (option 'a))` |
@@ -144,8 +148,9 @@ So the §4.1 `option` spec, written out in the real pure syntax, is:
     (#rw (case (some a) b f) (f a))))
 ```
 
-The remaining sections keep using the lighter sugar for legibility, but
-that table is the whole translation — there is nothing else to it.
+The remaining sections of this doc keep writing the lighter informal
+notation for legibility, but remember it is just exposition: the table
+above is the whole story, and only the right-hand column is a language.
 
 ### 1.4 The term sublanguage (and lifting it into the TCB)
 
@@ -186,7 +191,8 @@ hand-threaded `Term::app` / `Term::abs` Rust. The directive and proof
 layers stay firmly outside the TCB (they only ever *produce checkable
 obligations*); the term sublanguage is the one piece we may choose to
 trust directly, so it is kept as a sharply-delimited grammar from the
-start. A first sketch of the AST lives in
+start. A first sketch of the AST — and a parser (`parse` / `parse_str`)
+lowering pure S-expressions into it — lives in
 [`crates/covalence-hol/src/surface/`](../crates/covalence-hol/src/surface/).
 
 ---

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -91,6 +91,104 @@ The planner can be arbitrarily clever, learned, or simply wrong: a bad
 plan is slow or fails, but it is never *unsound*. That is precisely what
 makes "the query planner can be an LLM" a safe thing to say out loud.
 
+### 1.3 Everything is a pure S-expression
+
+There is **no infix syntax**. The arrows, colons, and rewrite arrows
+that appear in this document — `'a -> 'b`, `none : option 'a`, `lhs =>
+rhs` — are **prose sugar for readability only**. The actual language is
+*pure S-expressions*, in which every reserved word is a **`#`-headed
+builtin**:
+
+| sugar (used in prose below) | pure form |
+|---|---|
+| `'a -> 'b` | `(#fn 'a 'b)` |
+| `none : option 'a` | `(#sig none (option 'a))` |
+| `lhs => rhs` | `(#rw lhs rhs)` |
+| `(= a b)` | `(#eq a b)` |
+| `λa. body` / `(lam a body)` | `(#lam a body)` |
+| `(newtype …)` | `(#newtype …)` |
+| `(by …)` | `(#by …)` |
+
+A token's **lexical class is a pure function of its spelling**, so the
+parser never needs scope to route it:
+
+- **`#…`** — a **builtin** keyword. This covers *both* the directive
+  heads (`#theory`, `#def`, `#thm`, …) *and* every type/term form head
+  (`#fn`, `#lam`, `#eq`, `#sel`, `#abs`, `#rep`, …). A `#foo` that is not
+  a known builtin is a *malformed* token, not a name — the parser rejects
+  it.
+- **`'…`** — a **type variable** (`'a`, `'b`).
+- **everything else** — an ordinary **name**, of two kinds: a *dotted
+  catalogue* reference into `defs/` (`coprod.case`, `option.some`,
+  `unit.nil`) or a *local* name (a bound variable or a symbol the
+  enclosing `#theory` declares: `option`, `some`, `e`, `f`). Whether a
+  local name is a bound variable or a declared constant is the
+  *elaborator's* decision; the parser only records the token.
+
+So the §4.1 `option` spec, written out in the real pure syntax, is:
+
+```scheme
+(#theory option
+  (#tydecl
+    (option 'a #ty))
+  (#decl
+    (#sig none (option 'a))
+    (#sig some (#fn 'a (option 'a)))
+    (#sig case (#fn (option 'a) 'b (#fn 'a 'b) 'b)))
+  (#clause
+    (#rw e none)
+    (#rw e (some a)))
+  (#clause
+    (#rw (case none b f) b))
+  (#clause
+    (#rw (case (some a) b f) (f a))))
+```
+
+The remaining sections keep using the lighter sugar for legibility, but
+that table is the whole translation — there is nothing else to it.
+
+### 1.4 The term sublanguage (and lifting it into the TCB)
+
+One fragment of the language is special enough to name on its own: the
+**term sublanguage**, the grammar that `#def` bodies and the leaves of
+`(#by …)` proofs are written in. It is a **simply-typed lambda
+calculus** over the kernel's two logical primitives and the `defs/`
+catalogue:
+
+```text
+term ::= NAME                         ;; var / local constant / dotted catalogue ref
+      |  (term term+)                 ;; curried application (f x y …)
+      |  (#lam x term)                ;; lambda  — (#lam (x A) term) to type-ascribe
+      |  (#eq term term)              ;; primitive equality  =
+      |  (#sel (x A) term)            ;; Hilbert choice  ε
+      |  (#abs SPEC (ty*) term)       ;; TypeSpec carrier→wrapper coercion
+      |  (#rep SPEC (ty*) term)       ;; TypeSpec wrapper→carrier coercion
+      |  NUMERAL                      ;; integer literal
+      |  (#blob …)                    ;; byte-string literal
+```
+
+Two properties make it worth isolating:
+
+1. **It supports lambdas.** `#lam` is the one non-trivial binder, and it
+   is what lets the sublanguage express the `defs/` bodies at all — `some
+   ≡ λa. abs (inl a)` becomes `(#lam a (#abs option ('a) (inl a)))`,
+   one-for-one with the Rust `let`-body.
+2. **It has no operational semantics of its own.** Consistent with §1.1,
+   the sublanguage *names* terms; it never *reduces* them. `case (some a)
+   b f = f a` is a theorem the kernel establishes, not a rewrite the
+   sublanguage performs.
+
+Because it is this small and this closed, the term sublanguage is the
+natural candidate to eventually **move into the TCB**: a trusted
+elaboration of just these constructors into kernel `Term`s would let us
+write the `defs/` catalogue *in this sublanguage* instead of in
+hand-threaded `Term::app` / `Term::abs` Rust. The directive and proof
+layers stay firmly outside the TCB (they only ever *produce checkable
+obligations*); the term sublanguage is the one piece we may choose to
+trust directly, so it is kept as a sharply-delimited grammar from the
+start. A first sketch of the AST lives in
+[`crates/covalence-hol/src/surface/`](../crates/covalence-hol/src/surface/).
+
 ---
 
 ## 2. Two artifacts: **specs** and **definitions**


### PR DESCRIPTION
Begin sketching the high-level "generalized Haskell" authoring language
from docs/surface-syntax.md as a new `surface` module in covalence-hol.

- Clarify in docs/surface-syntax.md that the language is *pure
  S-expressions*: the infix prose (`'a -> 'b`, `name : ty`, `lhs => rhs`)
  is sugar only; the real forms are `#`-headed builtins (`(#fn 'a 'b)`,
  `(#sig …)`, `(#rw …)`). Add a sugar→pure table, the three lexical name
  classes (#builtin / 'tyvar / dotted-catalogue-or-local), and a fully
  desugared rendering of the option spec.

- Carve out the *term sublanguage* (§1.4): a simply-typed lambda calculus
  (#lam, #eq, #sel, #abs/#rep, application) with no operational semantics
  of its own — the closed grammar we may eventually lift into the TCB to
  write `defs/` bodies in.

- surface::ast — Directive / Ty / Kind / Term AST with the name-class
  helper; surface::Builtin — the provisional `#`-keyword registry;
  surface::parse — a documented stub (registered in SKELETONS.md).

https://claude.ai/code/session_01CsSugy5scBQxMT6k69T4vd